### PR TITLE
Fix showing copy code buttons on hover

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -400,17 +400,25 @@ pre.prism-code {
   border-radius: var(--ifm-global-radius);
 }
 
-pre.prism-code button {
+button[class*='copyButton'] {
+  z-index: 1000;
+
   color: var(--ifm-color-primary-lightest);
   font-size: 0.8rem;
 
   border: 1px solid var(--ifm-color-primary-lightest);
 }
 
-pre.prism-code button:hover {
+button[class*='copyButton']:hover {
   color: white;
-
   border: 1px solid white;
+}
+
+div[class*='mdxCodeBlock']:hover button[class*='copyButton'],
+pre[class*='codeBlock']:hover button[class*='copyButton'],
+pre[class*='codeBlockContent']:hover button[class*='copyButton'] {
+  opacity: 1;
+  visibility: visible;
 }
 
 pre.prism-code code {


### PR DESCRIPTION
Right now, the **Copy** buttons on code blocks aren't showing properly in some situations. This PR aims to fix that by using better classnames in the global CSS file.