### PR TITLE
Add Hubspot feedback CSAT form

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -43,6 +43,14 @@ module.exports = {
       crossorigin: ''
     }
   ],
+  scripts: [
+    {
+      src:
+        'https://js.hs-scripts.com/4567453.js',
+      async: true,
+      defer: true,
+    },
+  ],
   themeConfig: {
     googleAnalytics: {
       trackingID: 'UA-64295674-3',


### PR DESCRIPTION
This PR just adds the Hubspot tracking script to enable the form itself.

Click this link to check it out: https://deploy-preview-331--netdata-docusaurus.netlify.app/docs/get?hsWebSurveyPreview=CSAT&hsWebSurveyTestId=741DBAF1-524F-441F-806B-F06B7553720E