### PR TITLE
Add product titles to reference docs

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -9,7 +9,7 @@ module.exports = {
   learn: [
     {
       type: 'category',
-      label: 'Learn',
+      label: 'Netdata',
       collapsed: false,
       items: [
         {
@@ -97,7 +97,7 @@ module.exports = {
       items: [
         {
           type: 'category',
-          label: 'Agent',
+          label: 'Netdata Agent',
           items: [
             'agent',
             'agent/getting-started',
@@ -573,7 +573,7 @@ module.exports = {
         },
         {
           type: 'category',
-          label: 'Cloud',
+          label: 'Netdata Cloud',
           items: [
             'cloud',
             'cloud/get-started',

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -271,7 +271,7 @@ html[data-theme='dark'] {
 }
 
 .searchZ {
-  z-index: 2 !important;
+  z-index: 200 !important;
 }
 
 body.search-open {

--- a/src/pages/styles.module.scss
+++ b/src/pages/styles.module.scss
@@ -23,7 +23,6 @@
   }
 
   .heroText {
-    z-index: 100;
     position: relative;
 
     .heroTagline {
@@ -53,7 +52,6 @@
   }
 
   .heroImage {
-    z-index: 10;
     position: absolute;
     top: calc(-6rem - 68px);
     right: -300px;

--- a/src/theme/DocItem/index.js
+++ b/src/theme/DocItem/index.js
@@ -52,14 +52,25 @@ function DocItem(props) {
   // See https://github.com/facebook/docusaurus/issues/3362
 
   const showVersionBadge = versions.length > 1;
+
+  // BEGIN CUSTOMIZATION 
+  // Figure out whether the document in question is a reference document for
+  // either the Netdata Agent or Netdata Cloud. If it is, add in a reference to
+  // that product in the page title.
+  let productRef = ``
+  if (permalink.includes('/docs/cloud')) {
+    productRef = `· Netdata Cloud`
+  } else if (permalink.includes('/docs/agent')) {
+    productRef = `· Netdata Agent`
+  }
+
   const metaTitle = title
-    ? `${title} ${titleDelimiter} ${siteTitle}`
+    ? `${title} ${productRef} ${titleDelimiter} ${siteTitle}`
     : siteTitle;
   const metaImageUrl = useBaseUrl(metaImage, {
     absolute: true,
   });
 
-  // BEGIN CUSTOMIZATION
   const isGuide = permalink.includes('/guides/');
   // END CUSTOMIZATION
 


### PR DESCRIPTION
This PR adds product titles to the meta title for the Agent/Cloud reference docs. This will clarify search results (Google, Swiftype) when the feature's name is identical (for example, alarm notifications in Cloud vs. Agent), and the user wants to be able to find the appropriate doc.

I also added **Netdata** before **Agent** & **Cloud** in the sidebar, and fixed a z-index bug.