### PR TITLE
Support passing username and branch to ingest script

### DIFF
--- a/ingest.js
+++ b/ingest.js
@@ -65,14 +65,11 @@ async function getRateLimit() {
 }
 
 async function getRootSha(user = 'netdata', repo = 'netdata', branch = 'master') {
-  console.log('Fetching sha from ' + `${user}/${repo}/branches/${branch}`)
-
   const { data: { commit: { sha } } } = await ax.get(`${user}/${repo}/branches/${branch}`)
   return sha
 }
 
 async function getNodes(rootSha, user = 'netdata', repo = 'netdata') {
-  console.log('Fetching nodes from ' + `${user}/${repo}/git/trees/${rootSha}?recursive=true`)
   const { data: { tree } } = await ax.get(`${user}/${repo}/git/trees/${rootSha}?recursive=true`)
   return tree
 }


### PR DESCRIPTION
Still in testing.

This could be useful for anyone developing locally who wants to ingest documentation changes from a specific branch on their fork of the `netdata/netdata` repo. Only supports that repo for now.