### PR TITLE
Remove blank Export page.

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -480,7 +480,7 @@ module.exports = {
             {
               type: 'category',
               label: 'Exporters',
-              items: 
+              items: [
                 'agent/web/api/exporters/prometheus',
                 'agent/web/api/exporters/shell',
               ]


### PR DESCRIPTION
Blank Exporter Readme is incorrectly included in the sidebar build. Shows up as the top search result and autocomplete for "Export."