### PR TITLE
Added dependency mdx loader to reuse mdx snippets

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@tailwindcss/typography": "^0.4.0",
     "axios": "^0.21.2",
     "clsx": "^1.1.1",
+    "docusaurus": "^2.0.0",
     "docusaurus-tailwindcss-loader": "file:plugins/docusaurus-tailwindcss-loader",
     "dotenv": "^8.2.0",
     "postcss": "^8.2.8",
@@ -36,6 +37,7 @@
   },
   "devDependencies": {
     "autoprefixer": "^10.2.5",
+    "mdx-loader": "^3.0.2",
     "postcss-loader": "^5.2.0",
     "postcss-preset-env": "^6.7.0",
     "tailwindcss": "^2.1.2"


### PR DESCRIPTION
In order to make our content reusable, we must be able to create atomic topics that we can include elsewhere. MDX loader enables us to store `.mdx` files which we can include in other `.mdx` files. 

Example: Let's say we have a disclaimer that appears across 10 different topics. The disclaimer could either be copied and pasted (makes our code unmaintainable) or be reused. 

Documentation about reusing .mdx files is available in the [docusaurus docs](https://docusaurus.io/docs/markdown-features/react#importing-markdown)