### PR TITLE
Remove checks.plugin from sidebar, as it's an internal collector.

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -190,7 +190,6 @@ module.exports = {
                 'agent/collectors/timex.plugin',
                 'agent/collectors/idlejitter.plugin',
                 'agent/collectors/tc.plugin',
-                'agent/collectors/checks.plugin',
                 'agent/collectors/diskspace.plugin',
                 'agent/collectors/freebsd.plugin',
                 'agent/collectors/macos.plugin',


### PR DESCRIPTION
As discussed in [Issue 11907](https://github.com/netdata/netdata/issues/11907#issuecomment-999003753).