### PR TITLE
Redirects for links to removed docs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -176,6 +176,10 @@
   to = "/docs/get-started"
 
 [[redirects]]
+  from = "/docs/agent/getting-started"
+  to = "/docs/get-started"
+
+[[redirects]]
   from = "/docs/agent/packaging/DISTRIBUTIONS"
   to = "/docs/agent/packaging/PLATFORM_SUPPORT"
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,10 +10,6 @@
   to = "/docs/cheatsheet"
 
 [[redirects]]
-  from = "/docs/agent/packaging/installer"
-  to = "/docs/get-netdata"
-
-[[redirects]]
   from = "/docs/agent/collectors/quickstart"
   to = "/docs/collect/enable-configure"
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -181,8 +181,12 @@
 
 [[redirects]]
   from = "/docs/agent/packaging/installer/methods/alpine"
-  to = "/docs/agent/packaging/installer/"
+  to = "/docs/agent/packaging/installer/methods/kickstart"
 
 [[redirects]]
   from = "/docs/agent/packaging/installer/methods/kickstart-64"
-  to = "/docs/agent/packaging/installer/"
+  to = "/docs/agent/packaging/installer/methods/kickstart#static-builds"
+
+[[redirects]]
+from = "/docs/agent/packaging/installer/methods/packages"
+to = "/docs/agent/packaging/installer/methods/kickstart#native-packages"

--- a/netlify.toml
+++ b/netlify.toml
@@ -153,7 +153,11 @@
 
 [[redirects]]
   from = "/docs/cloud/faq-glossary"
-  to = "/docs/cloud/faq"
+  to = "https://community.netdata.cloud/docs"
+
+  [[redirects]]
+  from = "/docs/cloud/faq"
+  to = "https://community.netdata.cloud/docs"
 
 [[redirects]]
   from = "/docs/agent/code_of_conduct"
@@ -164,17 +168,25 @@
   to = "/docs/export/external-databases"
 
 [[redirects]]
-  from = "/docs/cloud/faq"
-  to = "https://community.netdata.cloud/docs"
-
-[[redirects]]
   from = "/docs/agent/contributors"
   to = "/contribute/license"
 
 [[redirects]]
   from = "/docs/get"
   to = "/docs/get-started"
-  
+
 [[redirects]]
   from = "/docs/agent/get"
   to = "/docs/get-started"
+
+[[redirects]]
+  from = "/docs/agent/packaging/DISTRIBUTIONS"
+  to = "/docs/agent/packaging/PLATFORM_SUPPORT"
+
+[[redirects]]
+  from = "/docs/agent/packaging/installer/methods/alpine"
+  to = "/docs/agent/packaging/installer/"
+
+[[redirects]]
+  from = "/docs/agent/packaging/installer/methods/kickstart-64"
+  to = "/docs/agent/packaging/installer/"


### PR DESCRIPTION
I modified the `netlify.toml` file to make sure links to our deleted pages redirect the user to a useful place.
Also cleaned up a daisy chain for FAQs.
I consulted with Austin on both changes.