### PR TITLE
Added custom_edit_URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ description: >-
   Ready to get real-time visibility into your entire infrastructure? 
   This guide will help you get started on Netdata Cloud.
 image: /img/seo/cloud_get-started.png
-custom_edit_url: null
+custom_edit_url: link to GitHub source file
 ---
 
 import Callout from '@site/src/components/Callout'

--- a/contribute/contribute.mdx
+++ b/contribute/contribute.mdx
@@ -1,7 +1,7 @@
 ---
 title: Contribute to Netdata's open-source
 description: The Netdata team welcomes contributions to its open-source tools and projects. Let's get you started on the right path.
-custom_edit_url: null
+custom_edit_url: https://github.com/netdata/learn/blob/master/contribute/contribute.mdx
 slug: /
 ---
 

--- a/contribute/projects.mdx
+++ b/contribute/projects.mdx
@@ -1,7 +1,7 @@
 ---
 title: Index of open-source projects
 description: This page is an index of open-source projects related to Netdata. Projects are maintained by both Netdata employees and its community.
-custom_edit_url: null
+custom_edit_url: https://github.com/netdata/learn/blob/master/contribute/projects.mdx
 ---
 
 Netdata has open-source in its DNA, having started as an open-source project back in 2016. While developing the Netdata

--- a/docs/cheatsheet.mdx
+++ b/docs/cheatsheet.mdx
@@ -3,7 +3,7 @@ title: "Netdata management and configuration cheatsheet"
 description: "Connecting an Agent to the Cloud allows a Netdata Agent, running on a distributed node, to securely connect to Netdata Cloud via the encrypted Agent-Cloud link (ACLK)."
 image: /cheatsheet/cheatsheet-meta.png
 sidebar_label: Cheatsheet
-custom_edit_url: null
+custom_edit_url: https://github.com/netdata/learn/blob/master/docs/cheatsheet.mdx
 ---
 
 import Link from '@docusaurus/Link';

--- a/docs/cloud.mdx
+++ b/docs/cloud.mdx
@@ -1,7 +1,7 @@
 ---
 title: Netdata Cloud docs
 description: Netdata Cloud is real-time visibility for entire infrastructures. View key metrics, insightful charts, and active alarms from all your nodes.
-custom_edit_url: null
+custom_edit_url: https://github.com/netdata/learn/blob/master/docs/cloud.mdx
 ---
 
 import { Grid, Box, BoxList, BoxListItem } from '@site/src/components/Grid/'

--- a/docs/cloud/beta-architecture/new-architecture.md
+++ b/docs/cloud/beta-architecture/new-architecture.md
@@ -3,7 +3,7 @@ title: Test the New Cloud Architecture
 description: >-
   Would you like to be the first to try our new architecture and provide feedback? 
   If so, this guide will help you sign up for our beta testing group.
-custom_edit_url: null
+custom_edit_url: https://github.com/netdata/learn/blob/master/docs/cloud/beta-architecture/new-architecture.md
 ---
 
 To enhance the stability and reliability of Netdata Cloud, we did extensive work on our backend, and we would like to give you the opportunity 

--- a/docs/cloud/get-started.mdx
+++ b/docs/cloud/get-started.mdx
@@ -4,7 +4,7 @@ description: >-
   Ready to get real-time visibility into your entire infrastructure? 
   This guide will help you get started on Netdata Cloud.
 image: /img/seo/cloud_get-started.png
-custom_edit_url: null
+custom_edit_url: https://github.com/netdata/learn/blob/master/docs/cloud/get-started.mdx
 ---
 
 import Link from '@docusaurus/Link'

--- a/docs/cloud/insights/metric-correlations.md
+++ b/docs/cloud/insights/metric-correlations.md
@@ -1,7 +1,7 @@
 ---
 title: Metric Correlations
 description: Quickly find metrics and charts closely related to an anomaly anywhere in your infrastructure to discover the root cause faster.
-custom_edit_url: null
+custom_edit_url: https://github.com/netdata/learn/blob/master/docs/cloud/insights/metric-correlations.md
 ---
 
 The Metric Correlations feature lets you quickly find metrics and charts related to an anomaly or particular window of

--- a/docs/cloud/manage/invite-your-team.md
+++ b/docs/cloud/manage/invite-your-team.md
@@ -1,7 +1,7 @@
 ---
 title: Invite your team
 description: Invite your entire SRE, DevOPs, or ITOps team to Netdata Cloud to give everyone insights into your infrastructure from a single pane of glass.
-custom_edit_url: null
+custom_edit_url: https://github.com/netdata/learn/blob/master/docs/cloud/manage/invite-your-team.md
 ---
 
 Invite new users to your Space by clicking on **Invite Users** in the [Space](/docs/cloud/spaces) management area.

--- a/docs/cloud/manage/sign-in.mdx
+++ b/docs/cloud/manage/sign-in.mdx
@@ -1,7 +1,7 @@
 ---
 title: Sign in with email, Google, or GitHub
 description: Learn how signing in to Cloud works via one of our three authentication methods, plus some tips if you're having trouble signing in.
-custom_edit_url: null
+custom_edit_url: https://github.com/netdata/learn/blob/master/docs/cloud/manage/sign-in.mdx
 ---
 
 You can [sign in to Netdata](https://app.netdata.cloud/sign-in?cloudRoute=spaces?utm_source=docs&utm_content=sign_in_button_first_section) through one of three methods: email, Google, or GitHub. Email uses a

--- a/docs/cloud/manage/themes.md
+++ b/docs/cloud/manage/themes.md
@@ -1,7 +1,7 @@
 ---
 title: Choose your Netdata Cloud theme
 description: Switch between Light and Dark themes in Netdata Cloud to match your personal visualization preferences.
-custom_edit_url: null
+custom_edit_url: https://github.com/netdata/learn/blob/master/docs/cloud/manage/themes.md
 ---
 
 The Dark theme is the default for all new Netdata Cloud accounts.

--- a/docs/cloud/spaces.md
+++ b/docs/cloud/spaces.md
@@ -1,7 +1,7 @@
 ---
 title: Spaces
 description: Organize your infrastructure monitoring on Netdata Cloud by creating Spaces, then grouping your Agent-monitored nodes.
-custom_edit_url: null
+custom_edit_url: https://github.com/netdata/learn/blob/master/docs/cloud/spaces.md
 ---
 
 Spaces are high-level containers to help you organize your team members and the nodes they're able to view in each

--- a/docs/cloud/visualize/dashboards.md
+++ b/docs/cloud/visualize/dashboards.md
@@ -1,7 +1,7 @@
 ---
 title: Build new dashboards
 description: Design new dashboards that target your infrastructure's unique needs and share them with your team for targeted visual anomaly detection or incident response.
-custom_edit_url: null
+custom_edit_url: https://github.com/netdata/learn/blob/master/docs/cloud/visualize/dashboards.md
 ---
 
 With Netdata Cloud, you can build new dashboards that target your infrastructure's unique needs. Put key metrics from

--- a/docs/cloud/visualize/interact-new-charts.md
+++ b/docs/cloud/visualize/interact-new-charts.md
@@ -2,7 +2,7 @@
 title: Interact with charts
 description: "Learn how to get the most out of Netdata's charts. These charts will help you make sense of all the metrics at your disposal, helping you troubleshoot with real-time, per-second metric data"
 type: how-to
-custom_edit_url: null
+custom_edit_url: https://github.com/netdata/learn/blob/master/docs/cloud/visualize/interact-new-charts.md
 ---
 
 > ⚠️ This new version of charts is currently **only** available on Netdata Cloud. We didn't want to keep this valuable

--- a/docs/cloud/visualize/kubernetes.md
+++ b/docs/cloud/visualize/kubernetes.md
@@ -1,7 +1,7 @@
 ---
 title: Kubernetes visualizations
 description: Netdata Cloud features rich, zero-configuration Kubernetes monitoring for the resource utilization and application metrics of Kubernetes (k8s) clusters.
-custom_edit_url: null
+custom_edit_url: https://github.com/netdata/learn/blob/master/docs/cloud/visualize/kubernetes.md
 ---
 
 Netdata Cloud features enhanced visualizations for the resource utilization of Kubernetes (k8s) clusters, embedded in

--- a/docs/cloud/visualize/nodes.md
+++ b/docs/cloud/visualize/nodes.md
@@ -1,7 +1,7 @@
 ---
 title: Nodes view
 description: See charts from all your nodes in one pane of glass, then dive in to embedded dashboards for granular troubleshooting of ongoing issues.
-custom_edit_url: null
+custom_edit_url: https://github.com/netdata/learn/blob/master/docs/cloud/visualize/nodes.md
 ---
 
 The Nodes view lets you see and customize key metrics from any number of Agent-monitored nodes and seamlessly navigate

--- a/docs/cloud/visualize/overview.md
+++ b/docs/cloud/visualize/overview.md
@@ -1,7 +1,7 @@
 ---
 title: Overview
 description: The Overview uses composite charts to display real-time aggregated metrics from all the nodes in a given War Room.
-custom_edit_url: null
+custom_edit_url: https://github.com/netdata/learn/blob/master/docs/cloud/visualize/overview.md
 ---
 
 The Overview is one way to monitor infrastructure using Netdata Cloud. While the interface might look similar to local

--- a/docs/cloud/war-rooms.md
+++ b/docs/cloud/war-rooms.md
@@ -1,7 +1,7 @@
 ---
 title: War Rooms
 description: Netdata Cloud uses War Rooms to group related nodes and create insightful composite dashboards based on their aggregate health and performance.
-custom_edit_url: null
+custom_edit_url: https://github.com/netdata/learn/blob/master/docs/cloud/war-rooms.md
 ---
 
 War Rooms organize your connected nodes and provide infrastructure-wide dashboards using real-time metrics and

--- a/docs/docs.mdx
+++ b/docs/docs.mdx
@@ -2,7 +2,7 @@
 title: Netdata Docs
 description: Use Netdata's documentation to start your journey to being a monitoring expert. Learn about essential features, solve problems quickly, and start troubleshooting.
 sidebar_label: 'Home'
-custom_edit_url: null
+custom_edit_url: https://github.com/netdata/learn/blob/master/docs/docs.mdx
 id: docs
 slug: /
 ---


### PR DESCRIPTION
During the content audit, I've found 19 pages within the netdata/learn repository that had the following attribute in their frontmatter: 
```
custom_edit_URL: null
```
In turn, these pages didn't generate a "Edit this page" link at the bottom of each site which decreases the maintainability. 

I've added the respective source files in this PR.