### PR TITLE
Disable automatic BLC

### DIFF
--- a/.github/workflows/check-broken-links.yml
+++ b/.github/workflows/check-broken-links.yml
@@ -1,8 +1,8 @@
 name: Test internal links
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 17 * * *'
+#  schedule:
+#    - cron: '0 17 * * *'
 env:
   WEBSITE_URL: "https://learn.netdata.cloud/"
   ISSUE_TEMPLATE: ".github/workflows/check-broken-links.md"


### PR DESCRIPTION
Since the broken link checker doesn't really work at the moment, I disabled the automatic runs. 

We can still trigger the workflow manually.

In the mean time, we should be on the lookout for broken links in the netlify build log. Docusaurus has an in-built broken link checker. 