### PR TITLE
Feature-ingest multiple branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Read more about [how the ingest script works](ingest.md).
 
 ### Automated ingest via GitHub Actions
 
-This repo uses a GitHub Action called [`ingest.yml`](.github/ingest.yml) to run the `ingest.js` process.
+This repo uses a GitHub Action called [`ingest.yml`](.github/workflows/ingest.yml) to run the `ingest.js` process.
 
 This action runs at 14:00 UTC every day.
 
@@ -103,7 +103,7 @@ If there are changes to any documentation file, the GitHub Action creates a PR f
 team.
 
 The action can be configured to automatically assign one or more reviewers. To enable automatic assignments, uncomment
-the `# reviewers:` line at the end of [`ingest.yml`](.github/ingest.yml) and add the appropriate GitHub username(s)
+the `# reviewers:` line at the end of [`ingest.yml`](.github/workflows/ingest.yml) and add the appropriate GitHub username(s)
 either space- or comma-separated.
 
 ### Manual ingest via GitHub Actions

--- a/README.md
+++ b/README.md
@@ -87,11 +87,11 @@ $ docusaurus start
 As explained in the [contributing to Netdata's documentation](#contributing-to-netdatas-documentation) section above,
 most of the files in the `/docs` folder are mirrors of their original versions in the `netdata/netdata` repository.
 
-Documentation arrives in this repository via the [`ingest.js`](/scripts/ingest.js) script. This script uses the GitHub
+Documentation arrives in this repository via the [`ingest.js`](ingest.js) script. This script uses the GitHub
 API to gather and process all of Netdata's documentation, including changing file paths and overwriting links between
 documents, then places the files in the `/docs`, `/guides`, and `/contribute` folders.
 
-Read more about [how the ingest script works](/scripts/ingest.md).
+Read more about [how the ingest script works](ingest.md).
 
 ### Automated ingest via GitHub Actions
 

--- a/ingest.js
+++ b/ingest.js
@@ -8,10 +8,9 @@ dotenv.config()
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN
 const MIN_RATE_LIMIT = 50
 
-// Set the GitHub user and branch to fetch with axios. The defaults are
-// `netdata` and `master`. Setting these are useful in GitHub Actions or
-// manually triggering an ingest to test some unmerged code in a fork or branch
-// that's not the default.
+// Set the GitHub user and branch for every repo that this script
+// ingests.
+
 const repo_config = {
   //default values
   netdata_user: 'netdata',
@@ -395,7 +394,7 @@ async function ingest() {
 
   console.log(`Fetching root SHA for '${repo_config.netdata_user}/netdata' repo`)
   const rootSha = await getRootSha(repo_config.netdata_user, 'netdata', repo_config.netdata_branch)
-  console.log(`Fetching nodes from ${repo_config.netdata_branch} branch of ${repo_config.netdata_user} repo...`)
+  console.log(`Fetching nodes from ${repo_config.netdata_branch} branch of ${repo_config.netdata_user}/netdata repo...`)
   const nodes = await getNodes(rootSha)
 
   console.log(`Fetching root SHA for '${repo_config.github_user}/.github' repo...`)

--- a/ingest.md
+++ b/ingest.md
@@ -18,43 +18,55 @@
 ## Usage
 
 ```
-node ingest.js
+node ingest.js <options>
 ```
+
 
 ### Options
 
-The script takes two additional options: a GitHub username and a branch name. These options override the default
-username and branch to ingest documentation files from the `netdata/netdata` repository, which are `netdata` and
-`master`.
+- For each repository you can change the user and the branch from which the ingest script will pull, with the following 
+  keys (defaults are applied)  
 
-By overriding the defaults, you can test how a documentation file will look and operate when published on Netdata Learn,
-or test the functionality of the script itself.
+  - `netdata/netdata`
+  
+    - netdata_user: netdata
+    - netdata_branch: master
 
-**You must use these options together**.
+  - `netdata/.github`
 
-```
-node ingest.js USER BRANCH
-```
+    - github_user: netdata
+    - github_branch: main
+    
+  - `netdata/go.d.plugin`
 
-> Currently, these options only affect how `ingest.js` pulls files from the `netdata/netdata` repository. The other
-> repositories still ingest from the `netdata` user and `master` branches.
+    - go_d_plugin_user: netdata
+    - go_d_plugin_branch: master
 
-#### Example: Override branch only
+  - `netdata/agent-service-discovery`
 
-If you want to pull from a `dashboard` branch that exists _on the `netdata/netdata` repository, pass `netdata` for the
-username.
+    - agent_service_discovery_user: netdata
+    - agent_service_discovery_branch: master
 
-```
-node ingest.js netdata dashboard
-```
 
-#### Example: Override both user and branch
+#### Example 1: Override branch only
 
-For example, let's say you have a fork of the `netdata/netdata` repository under a GitHub account named `userXYZ`. You
-also have a `charts` branch on your fork that you want ingest on your local development environment. You would run:
+If you want to pull from a `mybranch` branch that exists on the `netdata/netdata` repository.
 
 ```
-node ingest.js userXYZ charts
+node ingest.js netdata_branch:mybranch
 ```
 
-`ingest.js` now pulls files from the `charts` branch from the `userXYZ/netdata` repository instead of the default.
+#### Example 2: Multiple ingest from multiple sources.
+
+For example, let's say you have a fork of the `netdata/netdata` and the `netdata/go.d.plugin` repository under a GitHub 
+account named `userXYZ`. You also have a `charts` branch on each forked repository. You would run:
+
+```
+node ingest.js netdata_user:userXYZ netdata_branch:charts go_d_plugin_user:userXYZ go_d_plugin_branch:charts
+```
+
+`ingest.js` now pulls files from the `charts` branch from each repository (`userXYZ/netdata` and `userXYZ/go.d.plugin`) 
+instead of the default. For the other repositories (`netdata/.github`, `netdata/agent-service-discovery`), it will 
+ingest from the default settings. 
+
+> In case you misspelled your branch name, ingest script will run with the default parameters

--- a/ingest.md
+++ b/ingest.md
@@ -29,23 +29,25 @@ node ingest.js <options>
 
   - `netdata/netdata`
   
-    - netdata_user: netdata
-    - netdata_branch: master
+    - netdata_user:_USER_ (_Default: netdata_)
+    - netdata_branch:_BRANCH_ (_Default: master_)
 
   - `netdata/.github`
 
-    - github_user: netdata
-    - github_branch: main
+    - github_user:_USER_ (_Default: netdata_)
+    - github_branch:_BRANCH_ (_Default: main_)
     
   - `netdata/go.d.plugin`
 
-    - go_d_plugin_user: netdata
-    - go_d_plugin_branch: master
+    - go_d_plugin_user:_USER_ (_Default: netdata_)
+    - go_d_plugin_branch:_BRANCH_ (_Default: master_)
 
   - `netdata/agent-service-discovery`
 
-    - agent_service_discovery_user: netdata
-    - agent_service_discovery_branch: master
+    - agent_service_discovery_user:_USER_ (_Default: netdata_)
+    - agent_service_discovery_branch:_BRANCH_ (_Default:master_)
+
+> Always keep in mind, not to leave spaces between the <key>:<value> pairs.
 
 
 #### Example 1: Override branch only
@@ -58,7 +60,7 @@ node ingest.js netdata_branch:mybranch
 
 #### Example 2: Multiple ingest from multiple sources.
 
-For example, let's say you have a fork of the `netdata/netdata` and the `netdata/go.d.plugin` repository under a GitHub 
+For example, let's say you have a fork of the `netdata/netdata` and the `netdata/go.d.plugin` repositories under a GitHub 
 account named `userXYZ`. You also have a `charts` branch on each forked repository. You would run:
 
 ```
@@ -69,4 +71,5 @@ node ingest.js netdata_user:userXYZ netdata_branch:charts go_d_plugin_user:userX
 instead of the default. For the other repositories (`netdata/.github`, `netdata/agent-service-discovery`), it will 
 ingest from the default settings. 
 
-> In case you misspelled your branch name, ingest script will run with the default parameters
+> In case you misspell the keys (netdata_user, go_d_plugin_user, etc), ingest script will run with the default parameters.
+> If you misspell the branch name, or the user, your ingest will fail with response 404 and message "Branch not found".

--- a/ingest.md
+++ b/ingest.md
@@ -24,7 +24,18 @@ node ingest.js <options>
 
 ### Options
 
-- For each repository you can change the user and the branch from which the ingest script will pull, with the following 
+The ingest script supports ingesting content from a number of repositories defined in line XX of `ingest.js`.
+You can specify a user and a branch for each of these allowed repositories. 
+
+Allowed repositories and their parameters
+
+<insert the docs you've already written here>
+
+### Example
+
+Let's assume you have a fork of the netdata/netdata repository on which you work. That repository is called yourname/netdata. Now, you want to ingest your branch called `staging` to test the feature in the learn repository. In order to do this, you need to run: 
+```bash
+node ???
   keys (defaults are applied)  
 
   - `netdata/netdata`


### PR DESCRIPTION
Hello everyone,

This PR updates the ingest script and adds the support to specify the user(forked) and branch for every repository it ingests docs from. This will help us when we are building the docs locally.

Before merging it, we must make sure that this change does not interact with any other build workflow.



