### PR TITLE
Improve docs feedback forms

### DIFF
--- a/src/theme/DocItem/index.js
+++ b/src/theme/DocItem/index.js
@@ -205,6 +205,22 @@ function DocItem(props) {
                       <div className="opacity-0 group-hover:opacity-100 transition absolute z-0 inset-0 bg-gradient-to-r from-green to-green-lighter rounded" />
                     }
                   </button>
+				  {/*Honeypot to catch spambots*/}
+				  <p class="invisible">
+                    <label>
+                      Don't fill this out if you're human:{' '}
+                      <input
+                        name="botfield"
+                        onChange={e =>
+                          setFormData(prevFormData => ({
+                            ...prevFormData,
+                            [e.target.name]: e.target.value,
+                          }))
+                        }
+                      />
+                    </label>
+                  </p>
+
                 </form>
               )}
 						</div>

--- a/src/theme/DocItem/index.js
+++ b/src/theme/DocItem/index.js
@@ -71,7 +71,7 @@ function DocItem(props) {
 		}
 	}, []);
 
-  const [formData, setFormData] = useState({ thumb: null, feedback: "" })
+  const [formData, setFormData] = useState({ thumb: null, feedback: "", url: metadata.permalink})
 
   const handleSubmit = e => {
     e.preventDefault();
@@ -161,6 +161,7 @@ function DocItem(props) {
                   method="post"
                   onSubmit={handleSubmit}
                 >
+				  <input type="hidden" name="url" aria-label="current url" value={formData.url} />
                   <input type="hidden" name="form-name" value="thumbs-voting" />
                   <input type="hidden" name="thumb" aria-label="How do you like it?" value={formData.thumb} />
                   <button

--- a/src/theme/DocItem/index.js
+++ b/src/theme/DocItem/index.js
@@ -71,7 +71,7 @@ function DocItem(props) {
 		}
 	}, []);
 
-  const [formData, setFormData] = useState({ thumb: null, feedback: "", url: metadata.permalink})
+  const [formData, setFormData] = useState({ thumb: null, feedback: "", url: metadata.permalink })
 
   const handleSubmit = e => {
     e.preventDefault();
@@ -161,7 +161,7 @@ function DocItem(props) {
                   method="post"
                   onSubmit={handleSubmit}
                 >
-				  <input type="hidden" name="url" aria-label="current url" value={formData.url} />
+                  <input type="hidden" name="url" aria-label="current url" value={formData.url} />
                   <input type="hidden" name="form-name" value="thumbs-voting" />
                   <input type="hidden" name="thumb" aria-label="How do you like it?" value={formData.thumb} />
                   <button


### PR DESCRIPTION
To improve the documentation feedback forms I added spambot catcher. 
However, we still need a field that captures the URL that a user submits feedback for. 
@novykh Any idea on where/ how to add that?