### PR TITLE
add Anomaly Advisor to sidebar

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -412,6 +412,7 @@ module.exports = {
           label: 'Troubleshooting with Netdata Cloud',
           items: [
             'cloud/insights/metric-correlations',
+            'cloud/insights/anomaly-advisor',
           ]
         },
         {


### PR DESCRIPTION
Add anomaly advisor under "Troubleshooting with Netdata Cloud". Similar to where metric correlations lives currently.