### PR TITLE
Fix href syntax

### DIFF
--- a/src/components/Collectors/_collector-components.jsx
+++ b/src/components/Collectors/_collector-components.jsx
@@ -54,7 +54,7 @@ export function CollectorConfiguration({ configURL, moduleName }) {
 
 			<p>
 				For all available options, please see the module{' '}
-				<a href={configURL}>configuration file</a>.
+				<a href="{configURL}">configuration file</a>.
 			</p>
 		</>
 	);


### PR DESCRIPTION
## Problem
When you supplement the URL to a collector config, it gets passed to `href={URL}` which is not the correct syntax to form a link. 

## Proposed solution

Add `"`