### PR TITLE
Pause cron job of external link checker

### DIFF
--- a/.github/workflows/check-broken-links-external.yml
+++ b/.github/workflows/check-broken-links-external.yml
@@ -1,8 +1,8 @@
 name: Test external links
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 18 * * *'
+#  schedule:
+#    - cron: '0 18 * * *'
 env:
   WEBSITE_URL: "https://learn.netdata.cloud/"
   ISSUE_TEMPLATE: ".github/workflows/check-broken-links.md"
@@ -13,15 +13,15 @@ jobs:
 
     steps:
     - name: Run BLC on internal links
-      run: npx broken-link-checker $WEBSITE_URL --ordered --exclude-internal --user-agent 'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.101 Safari/537.36'
+      run: npx broken-link-checker $WEBSITE_URL --ordered --recursive --exclude-internal --user-agent 'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.101 Safari/537.36'
 
-    - uses: actions/checkout@v2
-      if: failure()
-
-    - uses: JasonEtco/create-an-issue@v2
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        LINK_TYPE: external
-      with:
-        filename: ${{ env.ISSUE_TEMPLATE }}
-      if: failure()
+#    - uses: actions/checkout@v2
+#      if: failure()
+#
+#    - uses: JasonEtco/create-an-issue@v2
+#      env:
+#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        LINK_TYPE: external
+#      with:
+#        filename: ${{ env.ISSUE_TEMPLATE }}
+#      if: failure()

--- a/.github/workflows/check-broken-links-external.yml
+++ b/.github/workflows/check-broken-links-external.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Run BLC on internal links
-      run: npx broken-link-checker $WEBSITE_URL --ordered --recursive --exclude-internal --user-agent 'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.101 Safari/537.36'
+      run: npx broken-link-checker $WEBSITE_URL --ordered --exclude-internal --user-agent 'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.101 Safari/537.36'
 
     - uses: actions/checkout@v2
       if: failure()


### PR DESCRIPTION
Leaving the actual action but we will pause the scheduling and the issue creation to avoid flooding with "broken link" issues
