### PR TITLE
Include both  captcha and honeypot in learn feedback forms

### DIFF
--- a/src/theme/DocItem/index.js
+++ b/src/theme/DocItem/index.js
@@ -119,7 +119,9 @@ function DocItemContent(props) {
 			<form
 				data-netlify="true"
 				name="docs-feedback"
-				method="post"
+				method="POST"
+				netlify-honeypot="bot-field"
+				data-netlify-recaptcha="true"
 				onSubmit={handleSubmit}
 			>
 				<input
@@ -193,7 +195,7 @@ function DocItemContent(props) {
 						}
 					/>
 				</div>
-
+                <div data-netlify-recaptcha="true"></div>
 				<button
 					type="submit"
 					disabled={!formData.thumb && !formData.feedback}


### PR DESCRIPTION
This PR enables the honey-pot netlify feature for spam detection and adds netlify-captcha support for feedback form.

This is still WIP.

Signed-off-by: Tasos Katsoulas <tasos@netdata.cloud>