### PR TITLE
minor fix in toc tree 

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -506,9 +506,9 @@ module.exports = {
                 'agent/web/api/queries/sum',
               ]
             },
-            'agent/libnetdata/simple_pattern',
           ],
         },
+        'agent/libnetdata/simple_pattern',
       ]
     }
   ]

--- a/sidebars.js
+++ b/sidebars.js
@@ -25,7 +25,6 @@ module.exports = {
             'overview/what-is-netdata',
             'overview/why-netdata',
             'overview/netdata-monitoring-stack',
-            'agent/libnetdata/simple_pattern',
             'agent/anonymous-statistics',
             'agent/netdata-security',
           ]
@@ -507,6 +506,7 @@ module.exports = {
                 'agent/web/api/queries/sum',
               ]
             },
+            'agent/libnetdata/simple_pattern',
           ],
         },
       ]

--- a/sidebars.js
+++ b/sidebars.js
@@ -501,6 +501,7 @@ module.exports = {
                 'agent/web/api/queries/max',
                 'agent/web/api/queries/median',
                 'agent/web/api/queries/min',
+                'agent/web/api/queries/countif',
                 'agent/web/api/queries/ses',
                 'agent/web/api/queries/stddev',
                 'agent/web/api/queries/sum',


### PR DESCRIPTION
* PR #1072 added a new guide to query, so we include it in TOC tree
* `agent/libnetdata/simple_pattern` was added by mistake in the _get started_  section of the TOC tree, we archived it under the _Developers_ cat of the TOC tree