### PR TITLE
Change learn navigation bar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -50,8 +50,8 @@ module.exports = {
 					label: 'Community',
 				},
 				{
-					to: 'https://netdata.cloud',
-					label: 'netdata.cloud',
+					to: 'https://app.netdata.cloud/?utm_source=learn&utm_content=top_navigation_sign_up',
+					label: 'Sign in',
 					position: 'right',
 				},
 				{


### PR DESCRIPTION
There is no point to have netdata.cloud on the navigation bar, let's change it to sign in to app.netdata.cloud

1. @lupimiguel is UTM ok? (just changed the learn from website)

