### PR TITLE
swizzle not found to fire 'page-not-found' event

### DIFF
--- a/src/theme/NotFound.js
+++ b/src/theme/NotFound.js
@@ -1,0 +1,49 @@
+import React, { useEffect } from 'react';
+import Layout from '@theme/Layout';
+import Translate, {translate} from '@docusaurus/Translate';
+import {PageMetadata} from '@docusaurus/theme-common';
+export default function NotFound() {
+  useEffect(() => {
+    window.posthog.capture('page-not-found');
+  }, [])
+  return (
+    <>
+      <PageMetadata
+        title={translate({
+          id: 'theme.NotFound.title',
+          message: 'Page Not Found',
+        })}
+      />
+      <Layout>
+        <main className="container margin-vert--xl">
+          <div className="row">
+            <div className="col col--6 col--offset-3">
+              <h1 className="hero__title">
+                <Translate
+                  id="theme.NotFound.title"
+                  description="The title of the 404 page">
+                  Page Not Found
+                </Translate>
+              </h1>
+              <p>
+                <Translate
+                  id="theme.NotFound.p1"
+                  description="The first paragraph of the 404 page">
+                  We could not find what you were looking for.
+                </Translate>
+              </p>
+              <p>
+                <Translate
+                  id="theme.NotFound.p2"
+                  description="The 2nd paragraph of the 404 page">
+                  Please contact the owner of the site that linked you to the
+                  original URL and let them know their link is broken.
+                </Translate>
+              </p>
+            </div>
+          </div>
+        </main>
+      </Layout>
+    </>
+  );
+}


### PR DESCRIPTION
This will fire a "page-not-found" event each time a user hits the not found page in learn. 

Here is an example user i did this with: https://app.posthog.com/person/183d15d0923d8a-09b312e5bdee77-26021f51-15f900-183d15d09248dd#activeTab=events

We will be able to use this to easily get volume based list of 404's users are actually hitting each day/week and clean them up based on traffic. 

![image](https://user-images.githubusercontent.com/2178292/195599461-314f3735-e5e6-4056-9a49-0da0b7caf2f5.png)
