### PR TITLE
Snooze issue notifications about BLC

### DIFF
--- a/.github/workflows/check-broken-links.yml
+++ b/.github/workflows/check-broken-links.yml
@@ -15,13 +15,13 @@ jobs:
     - name: Run BLC on internal links
       run: npx broken-link-checker $WEBSITE_URL --ordered --recursive --exclude-external --user-agent 'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.101 Safari/537.36'
 
-    - uses: actions/checkout@v2
-      if: failure()
-
-    - uses: JasonEtco/create-an-issue@v2
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        LINK_TYPE: internal
-      with:
-        filename: ${{ env.ISSUE_TEMPLATE }}
-      if: failure()
+#    - uses: actions/checkout@v2
+#      if: failure()
+#
+#    - uses: JasonEtco/create-an-issue@v2
+#      env:
+#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        LINK_TYPE: internal
+#      with:
+#        filename: ${{ env.ISSUE_TEMPLATE }}
+#      if: failure()


### PR DESCRIPTION
Until https://github.com/orgs/netdata/projects/39/views/7 be investigated, we will snooze the notification. To check for broken links your either:

1. Go to the latest run of this action and check the logs
2. Check the netlify build logs (docusaurus has it's own internal broken link checker)