### PR TITLE
Update the OneLineInstall component to include a checkbox for Cloud claiming

### DIFF
--- a/src/components/OneLineInstall/index.js
+++ b/src/components/OneLineInstall/index.js
@@ -10,11 +10,13 @@ export function OneLineInstallWget() {
   const [currentCommandUpdates, setCurrentCommandUpdates] = useState('');
   const [currentCommandRelease, setCurrentCommandRelease] = useState('');
   const [currentCommandStatistics, setCurrentCommandStatistics] = useState('');
+  const [currentCloudOption, setCurrentCloudOption] = useState('');
   const [updatesChecked, setUpdatesChecked] = useState(true);
   const [releaseChecked, setReleaseChecked] = useState(true);
   const [statsChecked, setStatsChecked] = useState(true);
+  const [cloudChecked, setCloudChecked] = useState(false);
 
-  let currentCommand = `wget -O /tmp/netdata-kickstart.sh https://my-netdata.io/kickstart.sh && sh /tmp/netdata-kickstart.sh${currentCommandUpdates}${currentCommandRelease}${currentCommandStatistics}`;
+  let currentCommand = `wget -O /tmp/netdata-kickstart.sh https://my-netdata.io/kickstart.sh && sh /tmp/netdata-kickstart.sh${currentCommandUpdates}${currentCommandRelease}${currentCommandStatistics}${currentCloudOption}`;
   const lang = `bash`
 
   function handleUpdatesChange() {
@@ -44,6 +46,16 @@ export function OneLineInstallWget() {
     } else {
       setCurrentCommandStatistics('');
       setStatsChecked(true);
+    }
+  }
+
+  function handleCloudChange() {
+    if (currentCloudOption === '' && cloudChecked == false) {
+      setCurrentCloudOption(' --claim-token YOUR_CLAIM_TOKEN --claim-rooms YOUR_ROOM_ID_A,YOUR_ROOM_ID_B');
+      setCloudChecked(true);
+    } else {
+      setCurrentCloudOption('');
+      setCloudChecked(false);
     }
   }
 
@@ -78,6 +90,14 @@ export function OneLineInstallWget() {
             type="checkbox" 
             id="toggle__stats" />
           <label htmlFor="toggle__stats" className="relative text-sm pl-2">Do you want to contribute <Link to="/docs/agent/anonymous-statistics" className="hover:text-blue">anonymous statistics?</Link> <code>default: enabled</code></label>
+        </div>
+        <div className="py-1 flex items-center">
+          <input
+            onChange={handleCloudChange}
+            checked={cloudChecked}
+            type="checkbox"
+            id="toggle__cloud" />
+          <label htmlFor="toggle__cloud" className="relative text-sm pl-2">Do you want to claim the node to Netdata Cloud?<code>default: disabled</code></label>
         </div>
       </div>
     </div>
@@ -89,11 +109,13 @@ export function OneLineInstallCurl() {
   const [currentCommandUpdates, setCurrentCommandUpdates] = useState('');
   const [currentCommandRelease, setCurrentCommandRelease] = useState('');
   const [currentCommandStatistics, setCurrentCommandStatistics] = useState('');
+  const [currentCloudOption, setCurrentCloudOption] = useState('');
   const [updatesChecked, setUpdatesChecked] = useState(true);
   const [releaseChecked, setReleaseChecked] = useState(true);
   const [statsChecked, setStatsChecked] = useState(true);
+  const [cloudChecked, setCloudChecked] = useState(false);
 
-  let currentCommand = `curl https://my-netdata.io/kickstart.sh > /tmp/netdata-kickstart.sh && sh /tmp/netdata-kickstart.sh${currentCommandUpdates}${currentCommandRelease}${currentCommandStatistics}`;
+  let currentCommand = `curl https://my-netdata.io/kickstart.sh > /tmp/netdata-kickstart.sh && sh /tmp/netdata-kickstart.sh${currentCommandUpdates}${currentCommandRelease}${currentCommandStatistics}${currentCloudOption}`;
   const lang = `bash`
 
   function handleUpdatesChange() {
@@ -126,6 +148,17 @@ export function OneLineInstallCurl() {
     }
   }
 
+  function handleCloudChange() {
+    if (currentCloudOption === '' && cloudChecked == false) {
+      setCurrentCloudOption(' --claim-token YOUR_CLAIM_TOKEN --claim-rooms YOUR_ROOM_ID');
+      setCloudChecked(true);
+    } else {
+      setCurrentCloudOption('');
+      setCloudChecked(false);
+    }
+  }
+
+
   return (
     <div className={clsx('relative overflow-hidden mt-8 mb-8 rounded-tr rounded-tl', styles.Container)}>
       <div className="text-lg lg:text-xl">
@@ -139,24 +172,32 @@ export function OneLineInstallCurl() {
             onChange={handleUpdatesChange}
             checked={updatesChecked}
             type="checkbox" 
-            id="toggle__updates"/>
-          <label htmlFor="toggle__updates" className="relative text-sm pl-2">Do you want automatic updates? <code>default: enabled</code></label>
+            id="toggle__updates_curl" />
+          <label htmlFor="toggle__updates_curl" className="relative text-sm pl-2">Do you want automatic updates? <code>default: enabled</code></label>
         </div>
         <div className="py-1 flex items-center">
           <input 
             onChange={handleReleaseChange}
             checked={releaseChecked}
             type="checkbox" 
-            id="toggle__type" />
-          <label htmlFor="toggle__type" className="relative text-sm pl-2">Do you want nightly or stable releases? <code>default: nightly</code></label>
+            id="toggle__type_curl" />
+          <label htmlFor="toggle__type_curl" className="relative text-sm pl-2">Do you want nightly or stable releases? <code>default: nightly</code></label>
         </div>
         <div className="py-1 flex items-center">
           <input 
             onChange={handleStatisticsChange}
             checked={statsChecked}
             type="checkbox" 
-            id="toggle__stats" />
-          <label htmlFor="toggle__stats" className="relative text-sm pl-2">Do you want to contribute <Link to="/docs/agent/anonymous-statistics" className="hover:text-blue">anonymous statistics?</Link> <code>default: enabled</code></label>
+            id="toggle__stats_curl" />
+          <label htmlFor="toggle__stats_curl" className="relative text-sm pl-2">Do you want to contribute <Link to="/docs/agent/anonymous-statistics" className="hover:text-blue">anonymous statistics?</Link> <code>default: enabled</code></label>
+        </div>
+        <div className="py-1 flex items-center">
+          <input
+            onChange={handleCloudChange}
+            checked={cloudChecked}
+            type="checkbox"
+            id="toggle__cloud_curl" />
+          <label htmlFor="toggle__cloud_curl" className="relative text-sm pl-2">Do you want to claim the node to Netdata Cloud?<code>default: disabled</code></label>
         </div>
       </div>
     </div>

--- a/src/components/OneLineInstall/index.js
+++ b/src/components/OneLineInstall/index.js
@@ -150,7 +150,7 @@ export function OneLineInstallCurl() {
 
   function handleCloudChange() {
     if (currentCloudOption === '' && cloudChecked == false) {
-      setCurrentCloudOption(' --claim-token YOUR_CLAIM_TOKEN --claim-rooms YOUR_ROOM_ID');
+      setCurrentCloudOption(' --claim-token YOUR_CLAIM_TOKEN --claim-rooms YOUR_ROOM_ID_A,YOUR_ROOM_ID_B');
       setCloudChecked(true);
     } else {
       setCurrentCloudOption('');

--- a/src/components/OneLineInstall/styles.module.css
+++ b/src/components/OneLineInstall/styles.module.css
@@ -1,5 +1,6 @@
 .Container * {
   margin: 0 !important;
+  white-space: break-spaces;
   /* // border-radius: 5px 5px 0 0 !important; */
 }
 


### PR DESCRIPTION
Discussed in https://github.com/netdata/documentation/issues/22.

I added a fourth button to the component, that is unchecked, and upon checking it adds the parameters needed for claiming to the Cloud and to war rooms.
- In this I set the Codeblock to have by default text wrapping, so the user can see how the command will be affected by the checkboxes. 
  If we instruct him to change stuff in the comment IMO it makes sense to show him the full command before he copies it. That being said, the Codeblock changing size as the user ticks stuff might be irritating, so use will tell if we revert back to having the whole box in one line
- <details><summary>I also fixed a bug of the OneLineInstallComponent</summary>
    If you go to the Component that is now live, and click a page that has both the wget and the curl version, try clicking at the curl's tixkboxe's text. The wget tickbox would get unchecked. This was due to the element ids being the same. Fixed.  
</details>


Note that this should be merged when the following are ready too:  
(links for the PRs will be provided here)