### PR TITLE
remove room id's from one line install widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ yarn start
 ```
 
 This command starts a local development server and opens up a browser window. Most changes are reflected live without
-having to restart the server.
+having to restart the server. If you want to suppress warnings you can run `yarn -s start`.
 
 If you get an error saying command not found when **docusaurus** is trying to start you need to install docusaurus (reference to [docusaurus on npm](https://www.npmjs.com/package/docusaurus)).
 

--- a/src/components/OneLineInstall/index.js
+++ b/src/components/OneLineInstall/index.js
@@ -51,7 +51,7 @@ export function OneLineInstallWget() {
 
   function handleCloudChange() {
     if (currentCloudOption === '' && cloudChecked == false) {
-      setCurrentCloudOption(' --claim-token YOUR_CLAIM_TOKEN --claim-rooms YOUR_ROOM_ID_A,YOUR_ROOM_ID_B');
+      setCurrentCloudOption(' --claim-token YOUR_CLAIM_TOKEN');
       setCloudChecked(true);
     } else {
       setCurrentCloudOption('');
@@ -150,7 +150,7 @@ export function OneLineInstallCurl() {
 
   function handleCloudChange() {
     if (currentCloudOption === '' && cloudChecked == false) {
-      setCurrentCloudOption(' --claim-token YOUR_CLAIM_TOKEN --claim-rooms YOUR_ROOM_ID_A,YOUR_ROOM_ID_B');
+      setCurrentCloudOption(' --claim-token YOUR_CLAIM_TOKEN');
       setCloudChecked(true);
     } else {
       setCurrentCloudOption('');

--- a/src/components/OneLineInstall/index.js
+++ b/src/components/OneLineInstall/index.js
@@ -97,7 +97,7 @@ export function OneLineInstallWget() {
             checked={cloudChecked}
             type="checkbox"
             id="toggle__cloud" />
-          <label htmlFor="toggle__cloud" className="relative text-sm pl-2">Do you want to claim the node to Netdata Cloud?<code>default: disabled</code></label>
+          <label htmlFor="toggle__cloud" className="relative text-sm pl-2">Do you want to <Link to="/docs/agent/claim" className="hover:text-blue">claim</Link> the node to Netdata Cloud?<code>default: disabled</code></label>
         </div>
       </div>
     </div>
@@ -197,7 +197,7 @@ export function OneLineInstallCurl() {
             checked={cloudChecked}
             type="checkbox"
             id="toggle__cloud_curl" />
-          <label htmlFor="toggle__cloud_curl" className="relative text-sm pl-2">Do you want to claim the node to Netdata Cloud?<code>default: disabled</code></label>
+          <label htmlFor="toggle__cloud_curl" className="relative text-sm pl-2">Do you want to <Link to="/docs/agent/claim" className="hover:text-blue">claim</Link> the node to Netdata Cloud?<code>default: disabled</code></label>
         </div>
       </div>
     </div>


### PR DESCRIPTION
i think we should have the claim part of the one line install widget just be as minimal as possible. 

this PR:

- removes the ROOM_ID stuff from the widget since you don't need it and its actually not that clear as a user how i would get my room id (we dont actually display it in All nodes in the app)
- links to claim docs in case user does not know what "claim" means.

end result is widget looks like this (only one thing to get and that's your claim token):

![image](https://user-images.githubusercontent.com/2178292/216028279-aa63e1bd-3bc0-49fe-adf9-15383a8e8ba9.png)

If we merge this then we can clean up the text marked with X in a follow on PR in netdata/netdata
