### PR TITLE
Create a GitHub styling reference md, for rules on using proper formatting, so docs are rendered properly in GitHub and Docusaurus

### DIFF
--- a/github_styling_reference.md
+++ b/github_styling_reference.md
@@ -1,0 +1,67 @@
+<!--
+title: "title_metadata"
+description: "description_metadata"
+...
+-->
+
+
+
+import { OneLineInstallWget, OneLineInstallCurl } from '@site/src/components/OneLineInstall/'
+import { Install, InstallBox } from '@site/src/components/Install/'
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Text regarding the document
+
+(we will use the below notes instead of github admonitions. To use the emojis, type a : and then start typing the emoji name. The ones we are going to use are: info -> "bookmark_tabs", tip -> "lightbulb", note -> "pencil2", warning -> "warning", caution -> "fire" )
+
+> 📑 Info
+>
+> This is an info block.
+
+> 💡 Tip
+> 
+> This is a tip block.
+
+> ✏️ Note
+> 
+> This is a note block.
+
+> ⚠️ Warning
+> 
+> This is a warning block.
+
+> 🔥 Caution
+> 
+> This is a caution block.
+
+
+## Header_Text
+
+Description of the header
+
+(when we use docusaurus tabs, we should have also the tab's name as a sentence in a heading below, as such:)
+
+<Tabs>
+<TabItem value="tab1" label="tab1">
+  
+<h3> Header for tab1 </h3>
+  
+text for tab1, both visible in GitHub and Docusaurus
+    
+    
+</TabItem>
+<TabItem value="tab2" label="tab2">
+    
+<h3> Header for tab2 </h3>
+    
+text for tab2, both visible in GitHub and Docusaurus
+
+</TabItem>
+</Tabs>
+
+(due to the nature of the way github reads HTML elements, we can't use the HTML codeblock element for tab labels, we will only use text, and it will be hidden from the preview)
+
+## Sample_Heading
+
+The text continues below...


### PR DESCRIPTION
## Summary

Upon discussion, we found out that elements that we were using for Docusaurus were rendering on GitHub, making the page full of weird artifacts that were in plaintext. 

We need a file that has the guideline on how to write in this manner, but that file should be GitHub only, not ingested in Learn.

This file proposes the best of both worlds, using a note system instead of "admonitions", and properly using headings around and inside a "Tab" and "TabItem" element in order to be able to see all the info correctly on both GitHub and Docusaurus.

### Comments

For comments, we are going to use:

---

#### Source text

```
> 📑 Info
>
> This is an info block.

> 💡 Tip
> 
> This is a tip block.

> ✏️ Note
> 
> This is a note block.

> ⚠️ Warning
> 
> This is a warning block.

> 🔥 Caution
> 
> This is a caution block.
```

I got a snippet in parenthesis inside the file about how to enter the emojis, you just type ":" and then start typing the name of the emojis (the names used here are listed in the file too, as a reference point)

---

#### How it renders in GitHub

> 📑 Info
>
> This is an info block.

> 💡 Tip
> 
> This is a tip block.

> ✏️ Note
> 
> This is a note block.

> ⚠️ Warning
> 
> This is a warning block.

> 🔥 Caution
> 
> This is a caution block.

---

#### How it renders in Docusaurus

![image](https://user-images.githubusercontent.com/70198089/216283260-992be43f-04bc-4ca2-b59c-16271abdfbf9.png)



### Tabs

For tabs a bit of jumping around hoops is required, but it is fairly straightforward. 

Tabs should always be the different options of an action, for example "wget" and "curl" for the kickstart script. That has to be like this, because to get everything working properly, one can't link to text inside the tabs, so we should link on the outside heading.

Fancy text can't be used either in the text of the tab, because it will render some artifacts on the GitHub side.

So we are going to do it this way:

---

#### Source text


```
## Header_Text

Description of the header

<Tabs>
<TabItem value="tab1" label="tab1">

<h3> Header for tab1 </h3>

text for tab1, both visible in GitHub and Docusaurus


</TabItem>
<TabItem value="tab2" label="tab2">

<h3> Header for tab2 </h3>

text for tab2, both visible in GitHub and Docusaurus

</TabItem>
</Tabs>
```

Headings inside tab elements MUST be HTML, otherwise they create a mess inside docusaurus's right hand navigation system.

---

#### How it renders in GitHub

## Header_Text

Description of the header

<Tabs>
<TabItem value="tab1" label="tab1">

<h3> Header for tab1 </h3>

text for tab1, both visible in GitHub and Docusaurus


</TabItem>
<TabItem value="tab2" label="tab2">

<h3> Header for tab2 </h3>

text for tab2, both visible in GitHub and Docusaurus

</TabItem>
</Tabs>

---

#### How it renders in Docusaurus

![image](https://user-images.githubusercontent.com/70198089/216282253-ef27e97e-0443-4b5b-8e93-88df2a4ace70.png)
