### PR TITLE
Make /docs the home page

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,10 @@
   environment = { NPM_VERSION = "7.10.0", NODE_VERSION = "16.14.2", NETLIFY_USE_YARN = "true" }
 
 [[redirects]]
+ from = "/"
+ to = "/docs"
+
+[[redirects]]
   from = "/docs/agent"
   to = "/docs"
 


### PR DESCRIPTION
- We're getting rid of guides anyway
- The news aren't being updated
- You don't see the links on the left unless you click on docs
- The top bar shows erroneoulsy nightly as selected
- /docs also looks like a home page