### PR TITLE
Fix a bug in the ingest script

### DIFF
--- a/ingest/ingest.py
+++ b/ingest/ingest.py
@@ -425,7 +425,7 @@ def convertGithubLinks(path, fileDict, DOCS_PREFIX):
                     replaceString = properLink[0] + properLink[1].strip("/")
 
                 # In the end replace the URL with the replaceString
-                body = body.replace(url, replaceString)
+                body = body.replace("]("+url, "]("+replaceString)
             except:
                 # This is probably a link that can't be translated to a Learn link (e.g. An external file)
                 pass


### PR DESCRIPTION
This is a fix that addresses files like [this file](https://github.com/netdata/netdata/blob/master/docs/cloud/manage/view-plan-billing.md?plain=1) at line 28 or other spots where we have a netdata github link, but not a markdown one.

In this case the ingest script at line 428 would replace all instances of the link including this occasion. adding a "](" to the target replace string and the replace value leads to fixing this bug.