### PR TITLE
Add a check for netdata links that can't be converted during ingest

### DIFF
--- a/ingest/ingest.py
+++ b/ingest/ingest.py
@@ -499,7 +499,7 @@ if __name__ == '__main__':
     '''Create local copies from the argpase input'''
     DOCS_PREFIX = args.DOCS_PREFIX
     for x in kArgs:
-        print(x)
+        # print(x)
         if x[0] == "repos":
             listOfReposInStr = x[1]
         if x[0] == "dryRun":


### PR DESCRIPTION
This PR adds the functionality to print a list of the broken links in the ingest process, with their temporary path, their custom_edit_url, and finally the URL itself, so one can bulk search for the URL and find where it is mentioned in a repository.

Along with this as discussed with @cakrit, it is intended that the ingest should fail upon detecting broken links, so this functionality has been added too, using the option `--fail-on-internal-broken-links` or `-f` for short.

By default failing on internal netdata broken links is disabled.