### PR TITLE
update referrer policy in header for better subdomain insights

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,10 @@
 # section: static << START
 
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Referrer-Policy = "no-referrer-when-downgrade"
+
 [build]
   environment = { NPM_VERSION = "7.10.0", NODE_VERSION = "16.14.2", NETLIFY_USE_YARN = "true" }
 


### PR DESCRIPTION
- this pr adds `Referrer-Policy: no-referrer-when-downgrade` header so we can see url path from where users are coming from when they move from one of our subdomains to another one.