### PR TITLE
Update ingest.yml to use newer version of `create-pull-request`

### DIFF
--- a/.github/workflows/ingest.yml
+++ b/.github/workflows/ingest.yml
@@ -36,7 +36,7 @@ jobs:
         mv tmp "${docfile}" || exit 1
 
     - name: Create pull request
-      uses: peter-evans/create-pull-request@v3
+      uses: peter-evans/create-pull-request@v4
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: Ingest new documentation


### PR DESCRIPTION
This PR bumps `peter-evans/create-pull-request` from `v3` to `v4`.
https://github.com/peter-evans/create-pull-request/blob/main/docs/updating.md#updating-from-v3-to-v4