### PR TITLE
Create sidebar_position inside the ingest script

### DIFF
--- a/ingest/ingest.py
+++ b/ingest/ingest.py
@@ -624,8 +624,6 @@ if __name__ == '__main__':
 
 
     mapDict['sidebar_position'] = np.arange(1, len(mapDict)+1)
-    print(mapDict['sidebar_position'])
-    # quit()
 
     reducedMarkdownFiles = []
     for md in markdownFiles:

--- a/ingest/ingest.py
+++ b/ingest/ingest.py
@@ -621,6 +621,12 @@ if __name__ == '__main__':
     mapDict = pd.read_csv("map.tsv",sep='\t')
     
     mapDict.set_index('custom_edit_url').T.to_dict('dict')
+
+
+    mapDict['sidebar_position'] = np.arange(1, len(mapDict)+1)
+    print(mapDict['sidebar_position'])
+    # quit()
+
     reducedMarkdownFiles = []
     for md in markdownFiles:
         #print("File: ", md)


### PR DESCRIPTION
This is fairly straightforward, we dont need "sidebar_position" inside our `map.tsv` file, as it is simply the row of the entries in that file.

Essentially `sidebar_position` is `np.arange(1, len(mapDict)+1)`, where mapDict is `map.tsv`