### PR TITLE
Add a new button to the bottom of the API page to have an outgoing link

### DIFF
--- a/static/api.html
+++ b/static/api.html
@@ -1,5 +1,6 @@
 <!-- HTML for static distribution bundle build -->
 <!DOCTYPE html>
+<html lang="en">
   <style>
     .customButton {
       width: 100%;

--- a/static/api.html
+++ b/static/api.html
@@ -1,6 +1,24 @@
 <!-- HTML for static distribution bundle build -->
 <!DOCTYPE html>
-<html lang="en">
+  <style>
+    .customButton {
+      width: 100%;
+      color: #ffffff;
+      background-color: #2b3136;
+      font-family : "IBM Plex Sans";
+      font-weight: 600;
+      font-size: 19px;
+      border: 0px solid #252829;
+      padding: 15px 50px;
+      cursor: pointer
+    }
+    button:hover {
+      color: #ffffff;
+      background-color: #00ab44;
+    }
+  </style>
+    
+
   <head>
     <meta charset="UTF-8">
     <title>Swagger UI</title>
@@ -12,6 +30,11 @@
 
   <body>
     <div id="swagger-ui"></div>
+    
+    <form action="https://learn.netdata.cloud/">
+      <button class="customButton" type="submit" name="backToLearnAPIButton">Back to Learn</button>
+   </form>
+
     <script src="./swagger-ui-bundle.js" charset="UTF-8"> </script>
     <script src="./swagger-ui-standalone-preset.js" charset="UTF-8"> </script>
     <script src="./swagger-initializer.js" charset="UTF-8"> </script>


### PR DESCRIPTION
Ahrefs reports that <https://learn.netdata.cloud/api> has no outgoing links, so let's test this with a "Back to Learn" button at the bottom of the file, it should be considered as an outgoing link, improving the page's score (and possibly searchability too)