### PR TITLE
Remove backticks from generated filenames

### DIFF
--- a/ingest/ingest.py
+++ b/ingest/ingest.py
@@ -237,7 +237,7 @@ def createMDXPathFromMetdata(metadata):
     In the returned (final) path we sanitize "/", "//" , "-", "," with one dash
     """
     finalFile = ' '.join(
-        (metadata["sidebar_label"].replace("'", " ").replace(":", " ").replace("/", " ").replace(")", " ").replace(",", " ").replace("(", " ")).split())
+        (metadata["sidebar_label"].replace("'", " ").replace(":", " ").replace("/", " ").replace(")", " ").replace(",", " ").replace("(", " ").replace("`", " ")).split())
 
     if "Monitor Anything" in metadata['learn_rel_path'] and metadata['learn_rel_path'].split("/")[-1] != "Monitor Anything":
         lastFolder = metadata['learn_rel_path'].split("Monitor Anything")[1]


### PR DESCRIPTION
Pages having "`" in the link are reported as non-canonical pages. Backticks (`) should not be in the link or generated filename. 