### PR TITLE
[REDO] Necessary changes for the monitor-anything category link fix

### DIFF
--- a/ingest/ingest.py
+++ b/ingest/ingest.py
@@ -243,9 +243,14 @@ def createMDXPathFromMetdata(metadata):
         lastFolder = metadata['learn_rel_path'].split("Monitor Anything")[1]
         lastFolder = "monitor-anything" + lastFolder.title()
         # print(lastFolder)
-        return ("{}/{}/{}.mdx".format(DOCS_PREFIX,
+        # If the file is inside the monitor-anything category, meaning that it will try to render the sidebar category label to whatever the folder has,
+        # return an array of two things; [the final path, the proper slug]. We use the slug to avoid having %20 (replacing spaces) in the link of the file.
+        return ["{}/{}/{}.mdx".format(DOCS_PREFIX,
                                       metadata["learn_rel_path"].split("Monitor Anything")[0].lower().replace(" ", "-") + lastFolder,
-                                      finalFile.replace(" ", "-")).replace("//", "/"))
+                                      finalFile.replace(" ", "-")).replace("//", "/"),
+                                      "/{}/{}".format(
+                                      metadata["learn_rel_path"],
+                                      finalFile.replace(" ", "-")).lower().replace(" ", "-").replace("//", "/")]
 
     else:
         return ("{}/{}/{}.mdx".format(DOCS_PREFIX,
@@ -326,6 +331,43 @@ def insertAndReadHiddenMetadataFromDoc(pathToFile, mapDict):
                 value = value.strip("\"")
                 metadataDictionary[key] = value.lstrip('>-')
     return metadataDictionary
+
+def update_metadata_of_file(pathToFile, dictionary):
+    """
+    Taking a path of a file as input
+    Identify the area with pattern " <!-- ...multiline string -->" and  converts them
+    to a dictionary of key:value pairs
+    """
+
+    output = ""
+    for field in dictionary:
+        try:
+            val = dictionary[field]
+        
+            # print((not val == np.nan),  val != val, val)
+            val = str(val)
+            output+= "{0}: \"{1}\"\n".format(field, val.replace("\"", ""))
+        except:
+            pass
+            # print("CANT PARSE", mapDict.loc[mapDict['custom_edit_url'] == key][field].values)
+    if len(output)>0:
+        output = "<!--\n" + output + "-->"
+        # print(output)
+
+    dummyFile = open(pathToFile, "r")
+    wholeFile = dummyFile.read()
+    dummyFile.close()
+
+    if wholeFile.startswith("<!--"):
+        body = wholeFile.split("-->", 1)[1]
+    else:
+        body = wholeFile
+
+    dummyFile = open(pathToFile, "w")
+    dummyFile.seek(0)
+    dummyFile.write(output + body)
+    dummyFile.close()
+
 
 def readDocusaurusMetadataFromDoc(pathToFile):
     """
@@ -422,8 +464,11 @@ def reductToPublishInGHLinksCorrelation(inputMatrix, DOCS_PREFIX, DOCS_PATH_LEAR
             outputDictionary[sourceLink] = properLink[0] + properLink[1].strip("/")
 
         _temp = outputDictionary[sourceLink].replace("'", " ").replace(":", " ").replace(")", " ").replace(",", " ").replace("(", " ").replace("/  +/g", ' ').replace(" ", "%20").replace('/-+/', '-')
-
-        inputMatrix[x].update({"newLearnPath": _temp })
+        # If there is a slug present in the file, then that is the newLearnPath, with a "/docs" added in the front.
+        try:
+            inputMatrix[x].update({"newLearnPath": "/docs"+inputMatrix[x]["metadata"]["slug"] })
+        except:
+            inputMatrix[x].update({"newLearnPath": _temp })
 
     return (inputMatrix)
 
@@ -703,13 +748,26 @@ if __name__ == '__main__':
             if "learn_status" in metadata.keys():
                 if metadata["learn_status"] == "Published":
                     try:
-                        toPublish[md] = {
+                        # check the type of the response (for more info of what the response can be check 
+                        # the return statements of the function itself)
+                        response = createMDXPathFromMetdata(metadata)
+                        if type(response) != str:
+                            metadata.update({"slug": str(response[1])})
+                            toPublish[md] = {
                             "metadata": metadata,
-                            "learnPath": str(createMDXPathFromMetdata(metadata)),
+                            "learnPath": str(response[0]),
                             "ingestedRepo": str(md.split("/", 2)[1])
-                        }
-                    except:
-                        print("File {} doesnt container key-value {}".format(md, KeyError))
+                            }    
+                            update_metadata_of_file(md, metadata)
+                        else:
+                            toPublish[md] = {
+                                "metadata": metadata,
+                                "learnPath": str(response),
+                                "ingestedRepo": str(md.split("/", 2)[1])
+                            }
+                    except Exception as e:
+                        print("File {} doesn't contain key-value {}".format(md, KeyError), e)
+
             else:
                 restFilesWithMetadataDictionary[md] = {
                     "metadata": metadata,


### PR DESCRIPTION
This is a redo of a reverted PR.

Related to https://github.com/netdata/learn/issues/1542 which affects only the category "Monitor Anything". 

Normally all folders should have a category overview page, but the content inside "Monitor Anything" is vast, making it hard and impractical to have a category page for every single folder.

This PR sets a new rule for files going on ".../monitor-anything/..." in which a `slug: ` metadata is added.

This metadata allows us to change the link that the page appears on, and it is set with the same rules as the rest of Learn.

The code is edited in such a way to only change lines where needed, meaning that we should take account somewhere if a file has a slug metadata, then we should change an element and the rest of the functions should work normally.

So the edits are:

`createMDXPathFromMetadata()`, here if the file is in "Monitor Anything" we return an array instead of the plain final path, so the second element of the array can be our desired slug.

`update_metadata_of_file()` is a new function necessary for the logic to work, as we have to go back in the file and append the slug metadata if it exists.

`reductToPublishInGHLinksCorrelation()` has been edited so that if there is a slug in the metadata, the newLearnPath will be changed to that, providing the correct string for the link fixing function and so on.