### PR TITLE
CSS changes and add on ingest right toc level 4

### DIFF
--- a/ingest/ingest.py
+++ b/ingest/ingest.py
@@ -269,6 +269,9 @@ def insert_and_read_hidden_metadata_from_doc(path_to_file, dictionary):
                     if val == "root":
                         # print("ROOT")
                         val = "/"
+                    
+                    if "Data collection" in  val:
+                        output += "toc_max_heading_level: 4\n"
 
                 if field == "sidebar_position":
                     output += "{0}: \"{1}\"\n".format(field, val.replace("\"", ""))

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -7,6 +7,22 @@
 
 /* custom Netdata overrides */
 
+.theme-doc-sidebar-item-link{
+	font-weight: 600;
+}
+
+.table-of-contents, .table-of-contents ul {
+	padding-left: unset;
+	font-weight: 600;
+}
+
+.menu .menu__link{
+	font-weight: 600 !important;
+}
+
+.markdown tbody td:last-child {
+	padding-right: .5714286em !important;
+}
 
 h1 {
 	font-size: 3.052rem !important;  /* adjust size as needed */


### PR DESCRIPTION
Fixed last table cell
Made ingest add the correct metadata for "Data collection" docs (will be visible on ingest, not now)
Made right hand TOC on every doc semibold and a bit less indented
Made Sidebar semibold too, to not have normal text being on the menu