### PR TITLE
Fixed swagger default URL

### DIFF
--- a/static/swagger-initializer.js
+++ b/static/swagger-initializer.js
@@ -3,7 +3,7 @@ window.onload = function() {
   console.log(window.location.pathname);
   // the following lines will be replaced by docker/configurator, when it runs in a docker-container
   window.ui = SwaggerUIBundle({
-    url: "https://raw.githubusercontent.com/netdata/netdata/master/web/api/netdata-swagger.json",
+    url: "https://raw.githubusercontent.com/netdata/netdata/master/src/web/api/netdata-swagger.json",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [


### PR DESCRIPTION
Hello,

Someone on the Discord server notified that learn.netdata.cloud/api was throwing an error and @ilyam8 forced me (help) to make a PR so here we are :-).

Default swagger URL changed when web/ folder got moved under src/ in main repo, related commit → https://github.com/netdata/netdata/commit/a75559dffe1beee48ce0942a86ad79fb7423c098