### PR TITLE
Add ML Accuracy documentation to navigation

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -92,7 +92,7 @@ module.exports = {
 						{
 							type: 'doc',
 							style: { 'color': 'white' },
-							docId: 'at-a-glance',
+							docId: 'welcome-to-netdata',
 							label: 'Documentation'
 						},
 						// {

--- a/map.tsv
+++ b/map.tsv
@@ -173,6 +173,7 @@ https://github.com/netdata/netdata/edit/master/docs/ml-ai/ai-devops-copilot/gemi
 https://github.com/netdata/netdata/edit/master/docs/ml-ai/ai-insights.md	AI Insights	Published	AI & ML	
 https://github.com/netdata/netdata/edit/master/docs/ml-ai/anomaly-advisor.md	Anomaly Advisor	Published	AI & ML	
 https://github.com/netdata/netdata/edit/master/docs/ml-ai/ml-anomaly-detection/ml-anomaly-detection.md	ML Anomaly Detection	Published	AI & ML/ML Anomaly Detection	
+https://github.com/netdata/netdata/edit/master/docs/ml-ai/ml-anomaly-detection/ml-accuracy.md	ML Accuracy	Published	AI & ML/ML Anomaly Detection	Analysis of Netdata's ML anomaly detection accuracy, false positive rates, and comparison with other approaches
 https://github.com/netdata/netdata/edit/master/src/ml/ml-configuration.md	ML Configuration	Published	AI & ML/ML Anomaly Detection	
 https://github.com/netdata/netdata/edit/master/docs/metric-correlations.md	Metric Correlations	Published	AI & ML/ML Anomaly Detection	Quickly find metrics and charts closely related to a particular timeframe of interest anywhere in your infrastructure to discover the root cause faster.
 				

--- a/map.tsv
+++ b/map.tsv
@@ -1,4 +1,5 @@
 custom_edit_url	sidebar_label	learn_status	learn_rel_path	description
+https://github.com/netdata/netdata/edit/master/docs/welcome-to-netdata.md	Welcome to Netdata	Published	root	
 https://github.com/netdata/netdata/edit/master/docs/netdata-enterprise-evaluation-corrected.md	At a glance	Published	root	
 https://github.com/netdata/netdata/edit/master/docs/deployment-guides/README.md	Deployment Guides	Published	Deployment Guides	
 https://github.com/netdata/netdata/edit/master/docs/deployment-guides/standalone-deployment.md	Standalone	Published	Deployment Guides	

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -51,7 +51,7 @@ export default function Home() {
 						container platforms (Kubernetes clusters, Docker), and many other
 						operating systems, with no <code>sudo</code> required.
 					</Box>
-					<Box to="/docs/at-a-glance" title="Docs" cta="Read the docs" image={false}>
+					<Box to="/docs/welcome-to-netdata" title="Docs" cta="Read the docs" image={false}>
 						Solution- and action-based docs for Netdata's many features and
 						capabilities. Your table of contents to becoming an expert in using
 						Netdata to monitor and troubleshoot applications and their


### PR DESCRIPTION
## Summary
This PR adds the new ML Accuracy documentation to the learn.netdata.cloud navigation structure.

## Navigation Path
The document will appear under:
**AI & ML** → **ML Anomaly Detection** → **ML Accuracy**

## Related PR
This PR depends on the documentation being added in: https://github.com/netdata/netdata/pull/20663

## What this adds
- Entry in map.tsv for the new ML accuracy analysis document
- Proper navigation structure under the ML Anomaly Detection section
- Description for the document in the TSV file

## Test plan
- [ ] Navigation structure displays correctly
- [ ] Document appears in the correct location
- [ ] Edit link works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)