### PR TITLE
Correcting Pages on Binary Distribution & Native Linux Install

### DIFF
--- a/docs/netdata-agent/installation/linux/native-linux-distribution-packages.mdx
+++ b/docs/netdata-agent/installation/linux/native-linux-distribution-packages.mdx
@@ -31,7 +31,7 @@ Our previous PackageCloud repositories are no longer updated. All packages are n
 Our repository system follows a structured organization:
 
 ```
-repository.netdata.cloud/repos/
+repo.netdata.cloud/repos/
 ├── stable/                   # Stable Netdata Agent releases
 │   ├── debian/               # For Debian-based distributions
 │   │   ├── bullseye/         # Distribution codename directories
@@ -56,12 +56,12 @@ repository.netdata.cloud/repos/
 
 ## Manual Setup of RPM Packages
 
-You can find our RPM repositories at: [https://repository.netdata.cloud/repos/index.html](https://repository.netdata.cloud/repos/index.html)
+You can find our RPM repositories at: [https://repo.netdata.cloud/repos/](https://repo.netdata.cloud/repos/)
 
 ### Available Repository Groups
 
 | Repo         | Purpose                       |
-|--------------|-------------------------------|
+| ------------ | ----------------------------- |
 | `stable`     | Stable Netdata Agent releases |
 | `edge`       | Nightly builds                |
 | `repoconfig` | Configuration packages        |
@@ -71,22 +71,23 @@ You can find our RPM repositories at: [https://repository.netdata.cloud/repos/in
 
 Within each repository group, you'll find directories for specific distributions:
 
-| Repository Directory | Primary Distribution | Compatible Distributions |
-|---------------------|----------------------|--------------------------|
-| `amazonlinux` | Amazon Linux | Binary-compatible Amazon Linux based distros |
-| `el` | Red Hat Enterprise Linux | CentOS, AlmaLinux, Rocky Linux, and other binary-compatible distros |
-| `fedora` | Fedora | Binary-compatible Fedora-based distros |
-| `ol` | Oracle Linux | Binary-compatible Oracle Linux based distros |
-| `opensuse` | openSUSE | Binary-compatible SUSE-based distros |
+| Repository Directory | Primary Distribution     | Compatible Distributions                                            |
+| -------------------- | ------------------------ | ------------------------------------------------------------------- |
+| `amazonlinux`        | Amazon Linux             | Binary-compatible Amazon Linux based distros                        |
+| `el`                 | Red Hat Enterprise Linux | CentOS, AlmaLinux, Rocky Linux, and other binary-compatible distros |
+| `fedora`             | Fedora                   | Binary-compatible Fedora-based distros                              |
+| `ol`                 | Oracle Linux             | Binary-compatible Oracle Linux based distros                        |
+| `opensuse`           | openSUSE                 | Binary-compatible SUSE-based distros                                |
 
 ### Repository Structure
 
 Each distribution has:
+
 1. Directories for each supported release version
 2. Subdirectories for each supported CPU architecture containing the actual packages
 
 **Example:** For RHEL 9 on 64-bit x86, you'll find the stable repository at:  
-[https://repository.netdata.cloud/repos/stable/el/9/x86_64/](https://repository.netdata.cloud/repos/stable/el/9/x86_64/)
+[https://repo.netdata.cloud/repos/stable/el/9/x86_64/](https://repo.netdata.cloud/repos/stable/el/9/x86_64/)
 
 ### Package Signing
 
@@ -94,12 +95,12 @@ Our RPM packages and repository metadata are signed with a GPG key with a userna
 `6E155DC153906B73765A74A99DD4A74CECFA8F4F`
 
 Download the public key from:  
-[https://repository.netdata.cloud/netdatabot.gpg.key](https://repository.netdata.cloud/netdatabot.gpg.key)
+[https://repo.netdata.cloud/netdatabot.gpg.key](https://repo.netdata.cloud/netdatabot.gpg.key)
 
 ### Installation Steps
 
 1. Download the appropriate config package for your distribution:  
-   [https://repository.netdata.cloud/repos/repoconfig/index.html](https://repository.netdata.cloud/repos/repoconfig/index.html)
+   [https://repo.netdata.cloud/repos/repoconfig](https://repo.netdata.cloud/repos/repoconfig)
 
 2. Install it with your package manager:
 
@@ -110,19 +111,19 @@ Download the public key from:
    ```
 
    :::note
-   
+
    On RHEL and other `el` repository distributions, some Netdata dependencies are in the EPEL repository. Our config packages typically handle this automatically, but if you encounter issues, install `epel-release` manually.
-   
+
    :::
 
 ## Manual Setup of DEB Packages
 
-You can find our DEB repositories at: [https://repository.netdata.cloud/repos/index.html](https://repository.netdata.cloud/repos/index.html)
+You can find our DEB repositories at: [https://repo.netdata.cloud/repos](https://repo.netdata.cloud/repos)
 
 ### Available Repository Groups
 
 | Repo         | Purpose                       |
-|--------------|-------------------------------|
+| ------------ | ----------------------------- |
 | `stable`     | Stable Netdata Agent releases |
 | `edge`       | Nightly builds                |
 | `repoconfig` | Configuration packages        |
@@ -153,7 +154,7 @@ Our DEB packages and repository metadata are signed with a GPG key with a userna
 `6E155DC153906B73765A74A99DD4A74CECFA8F4F`
 
 Download the public key from:  
-[https://repository.netdata.cloud/netdatabot.gpg.key](https://repository.netdata.cloud/netdatabot.gpg.key)
+[https://repo.netdata.cloud/netdatabot.gpg.key](https://repo.netdata.cloud/netdatabot.gpg.key)
 
 ### Example Configuration
 
@@ -164,24 +165,25 @@ Download the public key from:
 Here's an example APT sources entry for Debian 11 (Bullseye) stable releases:
 
 ```
-deb by-hash=yes http://repository.netdata.cloud/repos/stable/debian/ bullseye/
+deb by-hash=yes http://repo.netdata.cloud/repos/stable/debian/bullseye/
 ```
 
 And the equivalent Deb822 format:
 
 ```
 Types: deb
-URIs: http://repository.netdata.cloud/repos/stable/debian/
+URIs: http://repo.netdata.cloud/repos/stable/debian/
 Suites: bullseye/
 By-Hash: Yes
 Enabled: Yes
 ```
+
 </details>
 
 ### Installation Steps
 
 1. Download the appropriate config package for your distribution:  
-   [https://repository.netdata.cloud/repos/repoconfig/index.html](https://repository.netdata.cloud/repos/repoconfig/index.html)
+   [https://repo.netdata.cloud/repos/repoconfig](https://repo.netdata.cloud/repos/repoconfig)
 
 2. Install it using your package manager:
 
@@ -202,7 +204,7 @@ Here's a complete example of installing Netdata on Ubuntu 22.04 using native pac
 
 ```bash
 # Step 1: Download the repository configuration package
-wget https://repository.netdata.cloud/repos/repoconfig/ubuntu/jammy/netdata-repo_latest.jammy_all.deb
+wget https://repo.netdata.cloud/repos/repoconfig/ubuntu/jammy/netdata-repo_latest.jammy_all.deb
 
 # Step 2: Install the repository configuration
 sudo apt install ./netdata-repo_latest.jammy_all.deb
@@ -221,6 +223,7 @@ curl localhost:19999/api/v1/info
 ```
 
 After installation, you can access the Netdata dashboard at `http://localhost:19999`.
+
 </details>
 
 ## Local Mirrors of the Official Netdata Repositories
@@ -229,36 +232,35 @@ You can create local mirrors of our repositories using two main approaches:
 
 ### Recommended Mirroring Methods
 
-| Method           | Use case                              | Example |
-|------------------|---------------------------------------|---------|
-| Standard tools   | For formal repository mirroring | `aptly mirror create netdata-stable http://repository.netdata.cloud/repos/stable/debian/ bullseye/` |
-| Simple mirroring | For basic HTTP mirroring | `wget --mirror https://repository.netdata.cloud/repos/` |
+| Method           | Use case                        | Example                                                                                       |
+| ---------------- | ------------------------------- | --------------------------------------------------------------------------------------------- |
+| Standard tools   | For formal repository mirroring | `aptly mirror create netdata-stable http://repo.netdata.cloud/repos/stable/debian/ bullseye/` |
+| Simple mirroring | For basic HTTP mirroring        | `wget --mirror https://repo.netdata.cloud/repos/`                                             |
 
 ### Mirror Root URL
 
-[https://repository.netdata.cloud/repos/](https://repository.netdata.cloud/repos/)
+[https://repo.netdata.cloud/repos/](https://repo.netdata.cloud/repos/)
 
 ### Important Mirroring Tips
 
 :::important
 
-* **Repository config packages:** These don't support custom mirrors (except caching proxies like `apt-cacher-ng`). Configure mirrors manually.
-* **Build process:** Packages are built in stages by architecture (64-bit x86 first, then others). Full publishing takes several hours.
-* **Update frequency:** Metadata updates up to six times per hour, but syncing hourly is sufficient.
-* **Storage requirements:** A full mirror can require up to **100 GB** of space. Mirror only what you need.
-* **Recommended sync time:** For daily syncing, **05:00–08:00 UTC** is ideal, as nightly packages are typically published by then.
-* **GPG verification:** If using our GPG signatures, download our public key:  
-  [https://repository.netdata.cloud/netdatabot.gpg.key](https://repository.netdata.cloud/netdatabot.gpg.key)
+- **Repository config packages:** These don't support custom mirrors (except caching proxies like `apt-cacher-ng`). Configure mirrors manually.
+- **Build process:** Packages are built in stages by architecture (64-bit x86 first, then others). Full publishing takes several hours.
+- **Update frequency:** Metadata updates up to six times per hour, but syncing hourly is sufficient.
+- **Storage requirements:** A full mirror can require up to **100 GB** of space. Mirror only what you need.
+- **Recommended sync time:** For daily syncing, **05:00–08:00 UTC** is ideal, as nightly packages are typically published by then.
+- **GPG verification:** If using our GPG signatures, download our public key:  
+  [https://repo.netdata.cloud/netdatabot.gpg.key](https://repo.netdata.cloud/netdatabot.gpg.key)
 
 :::
 
 ## Public Mirrors of the Official Netdata Repositories
 
-There are currently no official public mirrors of our repositories. If you wish to provide a public mirror of our repositories, you are welcome to do so. 
+There are currently no official public mirrors of our repositories. If you wish to provide a public mirror of our repositories, you are welcome to do so.
 
 :::important
 
 Please clearly inform your users that your mirror is not officially supported by Netdata. We recommend following industry best practices for repository mirroring and security.
 
 :::
-

--- a/docs/netdata-agent/versions-&-platforms.mdx
+++ b/docs/netdata-agent/versions-&-platforms.mdx
@@ -14,12 +14,12 @@ Netdata is evolving rapidly and new features are added at a constant pace. There
 
 You can choose from 2 Netdata Agent release channels:
 
-| Release Channel |               Release Frequency               |                 Support Policy & Features                 |             Support Duration             |                              Backwards Compatibility                              |
-|:---------------:|:---------------------------------------------:|:---------------------------------------------------------:|:----------------------------------------:|:---------------------------------------------------------------------------------:|
+| Release Channel |                            Release Frequency                            |                 Support Policy & Features                 |             Support Duration             |                              Backwards Compatibility                              |
+| :-------------: | :---------------------------------------------------------------------: | :-------------------------------------------------------: | :--------------------------------------: | :-------------------------------------------------------------------------------: |
 |   **Stable**    | Usually 4-6 major/minor releases per year plus patch releases as needed | Receiving bug fixes and security updates between releases | Up to the 2nd stable release after them  |     Previous configuration semantics and data are supported by newer releases     |
-|   **Nightly**   |         Most nights around 02:00 UTC          |               Latest pre-released features                | Up to the 2nd nightly release after them |Configuration and data of unreleased features may change between nightly releases|
+|   **Nightly**   |                      Most nights around 02:00 UTC                       |               Latest pre-released features                | Up to the 2nd nightly release after them | Configuration and data of unreleased features may change between nightly releases |
 
-:::info  
+:::info
 
 "Support Duration" defines how long we consider each release actively used in production systems. After this period, you should update to the latest release to continue receiving bug fixes and security updates.
 
@@ -35,22 +35,23 @@ You can choose from 2 Netdata Agent release channels:
 
 We provide binary distribution packages via CI integration for the following platforms and architectures:
 
-|        Platform         |        Platform Versions         |          Released Packages Architecture          |    Format    |
-|:-----------------------:|:--------------------------------:|:------------------------------------------------:|:------------:|
-| **Docker under Linux** |         19.03 and later          | `x86_64`, `i386`, `ARMv7`, `AArch64`  | docker image |
-|   **Static Builds**    |                -                 | `x86_64`, `ARMv6`, `ARMv7`, `AArch64` |   .gz.run    |
-|    **Alma Linux**      |             8.x, 9.x             |               `x86_64`, `AArch64`                |     RPM      |
-|   **Amazon Linux**     |             2, 2023              |               `x86_64`, `AArch64`                |     RPM      |
-|      **Centos**        |               7.x                |                     `x86_64`                     |     RPM      |
-|       **Debian**       |         10.x, 11.x, 12.x         |       `x86_64`, `i386`, `ARMv7`, `AArch64`       |     DEB      |
-|       **Fedora**       |            37, 38, 39            |               `x86_64`, `AArch64`                |     RPM      |
-|      **OpenSUSE**      | Leap 15.4, Leap 15.5, Tumbleweed |               `x86_64`, `AArch64`                |     RPM      |
-|    **Oracle Linux**    |             8.x, 9.x             |               `x86_64`, `AArch64`                |     RPM      |
-| **Redhat Enterprise Linux** |               7.x                |                     `x86_64`                     |     RPM      |
-| **Redhat Enterprise Linux** |             8.x, 9.x             |               `x86_64`, `AArch64`                |     RPM      |
-|       **Ubuntu**       |       20.04, 22.04, 23.10        |       `x86_64`, `i386`, `ARMv7`, `AArch64`       |     DEB      |
+|          Platform           |     Platform Versions      |    Released Packages Architecture     |    Format    |
+| :-------------------------: | :------------------------: | :-----------------------------------: | :----------: |
+|   **Docker under Linux**    |      19.03 and later       | `x86_64`, `i386`, `ARMv7`, `AArch64`  | docker image |
+|      **Static Builds**      |             -              | `x86_64`, `ARMv6`, `ARMv7`, `AArch64` |   .gz.run    |
+|       **Alma Linux**        |          8.x, 9.x          |          `x86_64`, `AArch64`          |     RPM      |
+|      **Amazon Linux**       |          2, 2023           |          `x86_64`, `AArch64`          |     RPM      |
+|         **Centos**          |            7.x             |               `x86_64`                |     RPM      |
+|         **Debian**          |      10.x, 11.x, 12.x      | `x86_64`, `i386`, `ARMv7`, `AArch64`  |     DEB      |
+|         **Debian**          |            13.x            |     `x86_64`, `ARMv7`, `AArch64`      |     DEB      |
+|         **Fedora**          |           41, 42           |          `x86_64`, `AArch64`          |     RPM      |
+|        **OpenSUSE**         |   Leap 15.6, Tumbleweed    |          `x86_64`, `AArch64`          |     RPM      |
+|      **Oracle Linux**       |       8.x, 9.x, 10.x       |          `x86_64`, `AArch64`          |     RPM      |
+| **Redhat Enterprise Linux** |            7.x             |               `x86_64`                |     RPM      |
+| **Redhat Enterprise Linux** |          8.x, 9.x          |          `x86_64`, `AArch64`          |     RPM      |
+|         **Ubuntu**          | 20.04, 22.04, 24.04, 25.04 |     `x86_64`, `ARMv7`, `AArch64`      |     DEB      |
 
-:::important  
+:::important
 
 Linux distributions frequently provide binary packages of Netdata. However, **the packages you will find in the distributions' repositories may be outdated, incomplete, missing significant features or completely broken**. We recommend using the packages we provide.
 
@@ -60,8 +61,8 @@ Linux distributions frequently provide binary packages of Netdata. However, **th
 
 The following distributions always provide the latest stable version of Netdata:
 
-|  Platform  | Platform Versions |    Released Packages Architecture    |
-|:----------:|:-----------------:|:------------------------------------:|
+|    Platform    | Platform Versions |    Released Packages Architecture    |
+| :------------: | :---------------: | :----------------------------------: |
 | **Arch Linux** |      Latest       | All the Arch supported architectures |
 
 ## Builds from Source
@@ -70,13 +71,13 @@ We guarantee that you can build Netdata from source for the platforms where we p
 
 The following builds from source should usually work for you, although we don't regularly monitor if there are issues:
 
-|              Platform               |     Platform Versions      |
-|:-----------------------------------:|:--------------------------:|
-|      **Linux Distributions**       | Latest unreleased versions |
-|    **FreeBSD and derivatives**     |         14-STABLE          |
-|     **Gentoo and derivatives**     |           Latest           |
-|   **Arch Linux and derivatives**   |      latest from AUR       |
-|             **MacOS**               |         13, 14, 15         |
+|            Platform            |     Platform Versions      |
+| :----------------------------: | :------------------------: |
+|    **Linux Distributions**     | Latest unreleased versions |
+|  **FreeBSD and derivatives**   |         14-STABLE          |
+|   **Gentoo and derivatives**   |           Latest           |
+| **Arch Linux and derivatives** |      latest from AUR       |
+|           **MacOS**            |         13, 14, 15         |
 
 ## Static Builds and Unsupported Linux Versions
 
@@ -95,10 +96,10 @@ When a platform is removed from the Binary Distribution Packages list:
 
 - **No automatic transitions occur**: Your existing native package installations will remain as they are
 - **Your local updater will report the Agent as up-to-date** even when newer versions exist.
-- **When a new Netdata version is published, you'll see** "*Nodes are below the recommended Agent version*" **warnings** in the Netdata Cloud UI.
+- **When a new Netdata version is published, you'll see** "_Nodes are below the recommended Agent version_" **warnings** in the Netdata Cloud UI.
 - **You will stop receiving new features, improvements, and security updates**.
 
-:::important  
+:::important
 
 **We strongly recommend upgrading your operating system before it reaches EOL** to maintain full Netdata functionality and continued updates.
 


### PR DESCRIPTION
# [Netdata Binary Distribution Packages Page](https://learn.netdata.cloud/docs/netdata-agent/versions-&-platforms#binary-distribution-packages)

I noticed several error with distro support architecture and version. For instance, Fedora shows version 37, 38, 39 are currently supported, when in the Repo is actually 41 and 42.

Or Ubuntu, I couldn't find any packages that references to `i386` but rather `AMD64` (another term is `x86_64`)

---

# [Install Netdata Using Native DEB/RPM Packages](https://learn.netdata.cloud/docs/netdata-agent/installation/linux/native-linux-distribution-packages)

The problem is Netdata references to [https://repository.netdata.cloud/repos/index.html](https://repository.netdata.cloud/repos/index.html) which is while still active, it's unusable. In fact, `kickstart.sh` uses `https://repo.netdata.cloud/repos/`

And `/index.html` are removed since URL such as [https://repo.netdata.cloud/repos/index.html](https://repo.netdata.cloud/repos/index.html) results in Error `404 Not Found`. But [https://repo.netdata.cloud/repos without `./index.html`](https://repo.netdata.cloud/repos) works.

P.S. for maintainers, if I got any errors (both in data and style), please don't hesitate to edit some of the commits. Thank you.