### PR TITLE
Fix dark mode syntax highlighting in code blocks

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,5 +1,17 @@
 const {themes: prismThemes} = require('prism-react-renderer');
 
+// Extend Dracula with missing token type mappings for YAML, config files, etc.
+const draculaExtended = {
+	...prismThemes.dracula,
+	styles: [
+		...prismThemes.dracula.styles,
+		{types: ['number', 'boolean', 'constant', 'property'], style: {color: 'rgb(189, 147, 249)'}},  // purple
+		{types: ['atrule', 'keyword', 'key'], style: {color: 'rgb(139, 233, 253)'}},                   // cyan
+		{types: ['selector', 'tag'], style: {color: 'rgb(255, 121, 198)'}},                              // pink
+		{types: ['operator', 'entity', 'url'], style: {color: 'rgb(248, 248, 242)'}},                   // base white
+	],
+};
+
 /** @type {import('@docusaurus/types').DocusaurusConfig} */
 module.exports = {
 	title: 'Learn Netdata',
@@ -37,7 +49,7 @@ module.exports = {
 		},
 		prism: {
 			theme: prismThemes.github,
-			darkTheme: prismThemes.dracula,
+			darkTheme: draculaExtended,
 		},
 		image: 'img/netdata_meta-default.png',
 		docs: {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -153,6 +153,12 @@ html[data-theme='dark'] .table-of-contents__link--active {
 	font-weight: 600 !important;
 } */
 
+/* Table first/last column padding to avoid dense appearance */
+.markdown thead th:first-child,
+.markdown tbody td:first-child {
+	padding-left: .5714286em !important;
+}
+.markdown thead th:last-child,
 .markdown tbody td:last-child {
 	padding-right: .5714286em !important;
 }
@@ -564,35 +570,29 @@ html[data-theme='dark'] .markdown {
 	--tw-prose-captions: var(--ifm-font-color-base);
 	--tw-prose-th-borders: var(--ifm-table-border-color);
 	--tw-prose-td-borders: var(--ifm-table-border-color);
+	--tw-prose-pre-code: #e0e0e0;
+	--tw-prose-pre-bg: #1a1a1a;
+	--tw-prose-code: #e0e0e0;
 }
 
-/* Dark mode: Inline code text color */
-html[data-theme='dark'] code,
-html[data-theme='dark'] .markdown code,
-html[data-theme='dark'] .prose code {
+/* Dark mode: Inline code text color (exclude code blocks — Prism handles those) */
+html[data-theme='dark'] :not(pre) > code,
+html[data-theme='dark'] .markdown :not(pre) > code,
+html[data-theme='dark'] .prose :not(pre) > code {
 	color: #e0e0e0 !important;
 }
 
-/* Code blocks - light mode */
+/* Code blocks - light mode backgrounds */
 pre, .prism-code, [class*="codeBlock"] {
 	background-color: #e8e8e8 !important;
 	line-height: 1.0 !important;
 }
 
-pre code, .prism-code code, [class*="codeBlock"] code {
-	color: #1a1a1a !important;
-}
-
-/* Code blocks - dark mode */
+/* Code blocks - dark mode backgrounds */
 html[data-theme='dark'] pre,
 html[data-theme='dark'] .prism-code,
 html[data-theme='dark'] [class*="codeBlock"] {
 	background-color: #1a1a1a !important;
-}
-
-html[data-theme='dark'] pre code,
-html[data-theme='dark'] .prism-code code {
-	color: #e0e0e0;
 }
 
 .markdown ol > li::before  {


### PR DESCRIPTION
## Summary

- **Fix dark mode syntax highlighting**: The Dracula theme from `prism-react-renderer` is missing token type mappings for YAML-critical types (`key`, `atrule`, `number`, `boolean`, `property`), causing all code block text to render as monochrome white on dark backgrounds. Extended Dracula with the missing color mappings (cyan for keys, purple for numbers, pink for selectors).
- **Fix CSS overriding Prism colors**: The dark mode CSS rule `html[data-theme='dark'] code { color: #e0e0e0 !important }` was targeting ALL `<code>` elements including those inside code blocks, overriding Prism's per-token syntax colors. Scoped it to only inline code (`<code>` not inside `<pre>`).
- **Remove redundant overrides**: Removed `pre code { color: ... }` rules for both themes that were fighting with Prism's inline token styles.

## Test plan

- [ ] Restart dev server (config change requires restart)
- [ ] Check YAML code blocks on light theme — keys should be cyan, numbers teal
- [ ] Check YAML code blocks on dark theme — keys should be cyan, numbers purple, strings pink
- [ ] Check inline code (backtick) still renders correctly on both themes
- [ ] Check bash/shell code blocks highlight correctly on both themes