### PR TITLE
nedi: switch to ai-agent-ui v17 and mermaid 11.12.3

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -216,7 +216,7 @@ module.exports = {
 	],
 	stylesheets: [
 		// Nedi embed styles
-			'https://nedi.netdata.cloud/test.css?v=17',
+			'https://nedi.netdata.cloud/ai-agent-ui.css?v=17',
 		{
 			href: '/font/ibm-plex-sans-v8-latin-regular.woff2',
 			rel: 'preload',


### PR DESCRIPTION
## Summary
- bump Nedi embed asset URLs to `v=17` for freshness
- use canonical `ai-agent-ui.js` embed script
- bump CDN Mermaid runtime to `11.12.3`

## Validation
- attempted `CI=1 npm run build --silent`
- build compiles client/server successfully, but repository has an existing redirect conflict in finalization (`docs/ask-netdata/index.html`) unrelated to this change
