### PR TITLE
Add Nedi embed source tracking

### DIFF
--- a/src/components/Nedi/index.js
+++ b/src/components/Nedi/index.js
@@ -147,7 +147,9 @@ const CSS_VARIABLES = {
 };
 
 // Set source identifier for Nedi analytics
-window.AI_AGENT_UI_SOURCE = 'learn';
+if (typeof window !== 'undefined') {
+  window.AI_AGENT_UI_SOURCE = 'learn';
+}
 
 // Persistent container + instance, survives React unmounts
 function getOrCreateNedi(theme) {


### PR DESCRIPTION
## Summary

- Sets `window.AI_AGENT_UI_SOURCE = 'learn'` before the Nedi widget initializes
- The Nedi embed script (`ai-agent-ui.js`) reads this global variable and passes it through to the server, enabling per-source analytics (learn vs cloud-dashboard vs agent-dashboard)
- No behavioral changes — purely adds a source identifier for tracking

## Test plan

- [x] Verify Nedi loads normally on learn.netdata.cloud
- [x] Verify `window.AI_AGENT_UI_SOURCE` is set to `'learn'` in the browser console
- [x] Confirm no regressions in Nedi chat functionality