### PR TITLE
Update Nedi viz.js CDN dependency

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -255,7 +255,7 @@ module.exports = {
       // Nedi dependencies (CDN) - async to avoid blocking other scripts
       { src: 'https://cdn.jsdelivr.net/npm/markdown-it@14.1.1/dist/markdown-it.min.js', async: true },
       { src: 'https://cdn.jsdelivr.net/npm/mermaid@11.14.0/dist/mermaid.min.js', async: true },
-      { src: 'https://cdn.jsdelivr.net/npm/@viz-js/viz@3.25.0/dist/viz-global.js', async: true },
+      { src: 'https://cdn.jsdelivr.net/npm/@viz-js/viz@3.26.0/dist/viz-global.js', async: true },
       { src: 'https://cdn.jsdelivr.net/npm/turndown@7.2.4/dist/turndown.js', async: true },
       { src: 'https://cdn.jsdelivr.net/npm/@guyplusplus/turndown-plugin-gfm@1.0.7/dist/turndown-plugin-gfm.js', async: true },
       // Nedi embed


### PR DESCRIPTION
## Summary
- update the Nedi embed `@viz-js/viz` CDN URL from `3.25.0` to `3.26.0`
- keep the Learn docs-site embed in sync with the ai-agent and cloud-frontend Nedi assets

## Why
- `ai-agent` updated `@viz-js/viz` to the latest approved version in this dependency refresh
- `PACKAGE-UPDATES.md` in `ai-agent` requires the Nedi CDN versions to stay synchronized across repos

## Validation
- `npm run build`

## Notes
- the Learn build still emits the existing broken-anchor warnings on `master`, but the build completes successfully and this change does not introduce a new build failure