### PR TITLE
Use centralized Nedi home defaults

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -216,7 +216,7 @@ module.exports = {
 	],
 	stylesheets: [
 		// Nedi embed styles
-			'https://nedi.netdata.cloud/ai-agent-ui.css?v=17',
+			'https://nedi.netdata.cloud/ai-agent-ui.css?v=18',
 		{
 			href: '/font/ibm-plex-sans-v8-latin-regular.woff2',
 			rel: 'preload',
@@ -259,8 +259,8 @@ module.exports = {
       { src: 'https://cdn.jsdelivr.net/npm/turndown@7.2.4/dist/turndown.js', async: true },
       { src: 'https://cdn.jsdelivr.net/npm/@guyplusplus/turndown-plugin-gfm@1.0.7/dist/turndown-plugin-gfm.js', async: true },
       // Nedi embed
-      { src: 'https://nedi.netdata.cloud/ai-agent-public.js?v=17', async: true },
-      { src: 'https://nedi.netdata.cloud/ai-agent-ui.js?v=17', async: true },
+      { src: 'https://nedi.netdata.cloud/ai-agent-public.js?v=18', async: true },
+      { src: 'https://nedi.netdata.cloud/ai-agent-ui.js?v=18', async: true },
     ],
     headTags: [
       {

--- a/src/components/Nedi/index.js
+++ b/src/components/Nedi/index.js
@@ -5,120 +5,6 @@ const NEDI_ENDPOINT = 'https://nedi.netdata.cloud';
 const PERSISTENT_ID = 'nedi-persistent';
 const SCROLL_KEY = 'nedi-scroll-y';
 
-// Localized welcome phrases — randomly picked on each empty-chat view
-const HOME_WELCOME = {
-  en: [
-    "What's on your mind today?",
-    'How can I help?',
-    'What are you working on?',
-    'Where should we begin?',
-    'Ready when you are.',
-    "What's on the agenda today?",
-    'Hi! Ready to dive in?',
-    'Good to see you.',
-  ],
-  es: [
-    '¿Qué tienes en mente hoy?',
-    '¿Cómo puedo ayudarte?',
-    '¿En qué estás trabajando?',
-    '¿Por dónde empezamos?',
-    'Listo cuando quieras.',
-    '¿Qué hay en la agenda hoy?',
-    '¡Hola! ¿Empezamos?',
-    'Me alegra verte.',
-  ],
-  fr: [
-    "Qu'avez-vous en tête aujourd'hui ?",
-    'Comment puis-je vous aider ?',
-    'Sur quoi travaillez-vous ?',
-    'Par où commençons-nous ?',
-    'Prêt quand vous voulez.',
-    "Qu'y a-t-il au programme aujourd'hui ?",
-    'Bonjour ! On commence ?',
-    'Content de vous voir.',
-  ],
-  de: [
-    'Was haben Sie heute auf dem Herzen?',
-    'Wie kann ich helfen?',
-    'Woran arbeiten Sie?',
-    'Wo fangen wir an?',
-    'Bereit, wenn Sie es sind.',
-    'Was steht heute auf der Agenda?',
-    'Hallo! Bereit loszulegen?',
-    'Schön, Sie zu sehen.',
-  ],
-  pt: [
-    'O que você tem em mente hoje?',
-    'Como posso ajudar?',
-    'No que você está trabalhando?',
-    'Por onde começamos?',
-    'Pronto quando você quiser.',
-    'O que temos na agenda hoje?',
-    'Oi! Vamos começar?',
-    'Bom te ver.',
-  ],
-  zh: [
-    '今天有什么想法？',
-    '我能帮你什么？',
-    '你在做什么？',
-    '从哪里开始？',
-    '准备好了就开始吧。',
-    '今天的计划是什么？',
-    '你好！准备好了吗？',
-    '很高兴见到你。',
-  ],
-  ja: [
-    '今日は何をお考えですか？',
-    'お手伝いできることはありますか？',
-    '何に取り組んでいますか？',
-    'どこから始めましょうか？',
-    'いつでもどうぞ。',
-    '今日の予定は？',
-    'こんにちは！始めましょうか？',
-    'お会いできて嬉しいです。',
-  ],
-  ko: [
-    '오늘 무엇을 도와드릴까요?',
-    '어떻게 도와드릴까요?',
-    '무엇을 작업하고 계신가요?',
-    '어디서부터 시작할까요?',
-    '준비되시면 시작하겠습니다.',
-    '오늘의 일정은 무엇인가요?',
-    '안녕하세요! 시작할까요?',
-    '반갑습니다.',
-  ],
-};
-
-// Localized input placeholder — static, not rotating
-const HOME_PLACEHOLDER = {
-  en: 'Ask anything about Netdata...',
-  es: 'Pregunta lo que quieras sobre Netdata...',
-  fr: 'Posez vos questions sur Netdata...',
-  de: 'Fragen Sie alles über Netdata...',
-  pt: 'Pergunte qualquer coisa sobre o Netdata...',
-  zh: '问任何关于 Netdata 的问题...',
-  ja: 'Netdata について何でも聞いてください...',
-  ko: 'Netdata에 대해 무엇이든 물어보세요...',
-};
-
-// Hint suggestions shown below input on empty chat
-const HOME_HINTS = [
-  'Paste logs or error messages to trace issues in the code',
-  'Find alternatives for monitoring any technology or application',
-  'Create alerts tailored to your specific use cases',
-  'Help with deploying and sizing Netdata Parents',
-];
-
-// Quick links to top evergreen docs pages
-const HOME_QUICK_LINKS = [
-  { label: 'Install', url: '/docs/netdata-agent/installation' },
-  { label: 'Update', url: '/docs/netdata-agent/maintenance/update' },
-  { label: 'Uninstall', url: '/docs/netdata-agent/maintenance/uninstall' },
-  { label: 'Configure Alerts', url: '/docs/alerts-&-notifications' },
-  { label: 'Netdata Parents', url: '/docs/netdata-parents' },
-  { label: 'Collecting Metrics', url: '/docs/collecting-metrics' },
-];
-
 // Match Docusaurus theme colors for seamless integration
 const CSS_VARIABLES = {
   light: {
@@ -165,15 +51,11 @@ function getOrCreateNedi(theme) {
 
   const instance = new window.AiAgentChatUI(container, {
     mode: 'div',
+    agentId: 'support-public',
     theme,
     showThemeToggle: false,
     stickyInput: true,
     cssVariables: CSS_VARIABLES,
-    homeWelcome: HOME_WELCOME,
-    homePlaceholder: HOME_PLACEHOLDER,
-    homeHints: HOME_HINTS,
-    homeQuickLinks: HOME_QUICK_LINKS,
-    placeholders: [HOME_PLACEHOLDER.en],
     urlParams: ['q', 'question'],
     onEvent: (event) => {
       if (event.type === 'user-message' && window.posthog) {


### PR DESCRIPTION
## What changed

- Load the Nedi embed bundle at `?v=18`.
- Pass `agentId: support-public` so the embed UI can fetch home defaults from Nedi.
- Remove inline home welcome, placeholder, hints, and quick links from Learn.

## Why

Nedi home content is now owned by the Nedi embed service. Keeping it centralized avoids duplicated translation and prompt-surface content in consumer frontends.

## Backward compatibility

The Nedi embed bundle is fully backward compatible:

- The new backend serves both `?v=17` callers (still on inline `HOME_*`) and `?v=18` callers (using the centralized defaults). No coordinated cutover required.
- The new embed UI accepts both legacy array shapes (`homeHints: ["..."]`) and the new locale-keyed object shapes (`homeHints: {en: ["..."]}`).
- Removing the inline `HOME_*` constants in this PR is safe once the v18 Nedi embed bundle is live: the UI then fetches `/v1/embed-home/support-public` from Nedi and renders 16-language defaults.

## Validation

- `npm run build` passed.
- The build still reports existing Docusaurus warnings for broken anchors, duplicate routes, and missing blog directory; those are unrelated to this change.

## Rollout

Merge after `https://nedi.netdata.cloud` serves the v18 embed bundle so the home tab populates from the centralized JSON. Browsers cached on `?v=17` continue to work without regression while the consumer is on either version.