### PR TITLE
ingest: route flows integrations into the Network Flows section

### DIFF
--- a/ingest/ingest.py
+++ b/ingest/ingest.py
@@ -760,6 +760,7 @@ def populate_integrations(markdownFiles):
     authentication_entries = pd.DataFrame()
     secretstore_entries = pd.DataFrame()
     logs_entries = pd.DataFrame()
+    flows_entries = pd.DataFrame()
 
     readmes_first = []
     others_last = []
@@ -841,6 +842,11 @@ def populate_integrations(markdownFiles):
                 )
 
                 logs_entries = pd.concat([logs_entries, metadf])
+            elif "netflow-plugin/integrations" in normalized_file:
+                # Network Flow integrations live under
+                # src/crates/netflow-plugin/integrations/<slug>.md and are
+                # spliced into the map at the `flows_integrations` placeholder.
+                flows_entries = pd.concat([flows_entries, metadf])
             else:
                 alerting_agent_entries = pd.concat([alerting_agent_entries, metadf])
 
@@ -987,6 +993,25 @@ def populate_integrations(markdownFiles):
         ],
         ignore_index=True,
     )
+
+    replace_index = map_file.loc[
+        map_file["custom_edit_url"] == "flows_integrations"
+    ].index
+    if len(replace_index) > 0:
+        upper = map_file.iloc[: replace_index[0]]
+        lower = map_file.iloc[replace_index[0] + 1 :]
+
+        map_file = pd.concat(
+            [
+                upper,
+                flows_entries.sort_values(
+                    by=["learn_rel_path", "sidebar_label"],
+                    key=lambda col: col.str.lower(),
+                ),
+                lower,
+            ],
+            ignore_index=True,
+        )
 
     # Convert DataFrame to list of dicts and save as YAML
     generated_map_data = map_file.to_dict(orient="records")


### PR DESCRIPTION
## Summary

The Netdata Agent introduces a new top-level `integration_type`, `flows`, covering NetFlow / IPFIX / sFlow sources, IP intelligence sources, BGP routing sources, and network identity sources. Their integration markdown lives under `src/crates/netflow-plugin/integrations/<slug>.md` in the agent repo, and `docs/.map/map.yaml` references them via an `integration_placeholder` with `integration_kind: flows`.

This PR teaches `ingest/ingest.py` to recognise and place those entries.

Two surgical changes mirroring the existing logs handling:

1. **Categorise**: files whose path contains `netflow-plugin/integrations` go into a new `flows_entries` DataFrame instead of the catch-all `alerting_agent_entries` bucket.
2. **Splice**: after the logs replacement step, `flows_entries` is spliced over the `flows_integrations` placeholder row using the same `upper / concat / lower` pattern used by every other integration kind. Wrapped in `len(replace_index) > 0` so older netdata revisions without the placeholder still ingest cleanly.

This unblocks the Network Flows section on `learn.netdata.cloud` once the netdata Agent companion PR (https://github.com/netdata/netdata/pull/22439) merges.

## Test plan

- [x] Run `ingest/ingest.py` against the agent branch with the new `flows` placeholder — 65 Network Flows rows are spliced into `ingest/generated_map.yaml` under their four sub-categories (Sources, IP Intelligence, BGP Routing, Network Identity Sources); no `flows_integrations` placeholder remains; script exits 0.
- [ ] Re-run `ingest/ingest.py` against current master of the agent (no placeholder yet) — verify the script still completes (the `len(replace_index) > 0` guard handles the missing placeholder).
- [ ] Manual verify the Learn site renders the Network Flows section after merge of the agent PR.