### PR TITLE
Update Nedi CDN pins

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -254,8 +254,8 @@ module.exports = {
       },
       // Nedi dependencies (CDN) - async to avoid blocking other scripts
       { src: 'https://cdn.jsdelivr.net/npm/markdown-it@14.1.1/dist/markdown-it.min.js', async: true },
-      { src: 'https://cdn.jsdelivr.net/npm/mermaid@11.14.0/dist/mermaid.min.js', async: true },
-      { src: 'https://cdn.jsdelivr.net/npm/@viz-js/viz@3.26.0/dist/viz-global.js', async: true },
+      { src: 'https://cdn.jsdelivr.net/npm/mermaid@11.15.0/dist/mermaid.min.js', async: true },
+      { src: 'https://cdn.jsdelivr.net/npm/@viz-js/viz@3.27.0/dist/viz-global.js', async: true },
       { src: 'https://cdn.jsdelivr.net/npm/turndown@7.2.4/dist/turndown.js', async: true },
       { src: 'https://cdn.jsdelivr.net/npm/@guyplusplus/turndown-plugin-gfm@1.0.7/dist/turndown-plugin-gfm.js', async: true },
       // Nedi embed


### PR DESCRIPTION
## Summary

- Update Nedi embed CDN pins for Mermaid and Viz.js in the Docusaurus config.
- Keep the CDN versions aligned with ai-agent's current embed test files.

## Validation

- `node --check docusaurus.config.js`
- `git diff --check`

## Notes

- `package.json` and `package-lock.json` already reference `mermaid@11.15.0` on this branch base, so only the Docusaurus CDN config needed a change.