### PR TITLE
Update Nedi Graphviz CDN dependency

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -255,7 +255,7 @@ module.exports = {
       // Nedi dependencies (CDN) - async to avoid blocking other scripts
       { src: 'https://cdn.jsdelivr.net/npm/markdown-it@14.2.0/dist/markdown-it.min.js', async: true },
       { src: 'https://cdn.jsdelivr.net/npm/mermaid@11.15.0/dist/mermaid.min.js', async: true },
-      { src: 'https://cdn.jsdelivr.net/npm/@viz-js/viz@3.27.0/dist/viz-global.js', async: true },
+      { src: 'https://cdn.jsdelivr.net/npm/@viz-js/viz@3.28.0/dist/viz-global.js', async: true },
       { src: 'https://cdn.jsdelivr.net/npm/turndown@7.2.4/dist/turndown.js', async: true },
       { src: 'https://cdn.jsdelivr.net/npm/@guyplusplus/turndown-plugin-gfm@1.0.7/dist/turndown-plugin-gfm.js', async: true },
       // Nedi embed


### PR DESCRIPTION
Summary:
- Update the Nedi embed @viz-js/viz CDN URL to 3.28.0.
- Keep the Learn CDN pin synchronized with ai-agent.

Validation:
- git diff --check