### PR TITLE
ingest: add service_discovery bucket to populate_integrations

### DIFF
--- a/ingest/ingest.py
+++ b/ingest/ingest.py
@@ -761,6 +761,7 @@ def populate_integrations(markdownFiles):
     secretstore_entries = pd.DataFrame()
     logs_entries = pd.DataFrame()
     flows_entries = pd.DataFrame()
+    service_discovery_entries = pd.DataFrame()
 
     readmes_first = []
     others_last = []
@@ -847,6 +848,11 @@ def populate_integrations(markdownFiles):
                 # src/crates/netflow-plugin/integrations/<slug>.md and are
                 # spliced into the map at the `flows_integrations` placeholder.
                 flows_entries = pd.concat([flows_entries, metadf])
+            elif "/discovery/sdext/discoverer/" in normalized_file:
+                # Service Discovery integrations live under
+                # src/go/plugin/go.d/discovery/sdext/discoverer/*/integrations/*.md
+                # and are spliced into the map at the `service_discovery_integrations` placeholder.
+                service_discovery_entries = pd.concat([service_discovery_entries, metadf])
             else:
                 alerting_agent_entries = pd.concat([alerting_agent_entries, metadf])
 
@@ -1005,6 +1011,25 @@ def populate_integrations(markdownFiles):
             [
                 upper,
                 flows_entries.sort_values(
+                    by=["learn_rel_path", "sidebar_label"],
+                    key=lambda col: col.str.lower(),
+                ),
+                lower,
+            ],
+            ignore_index=True,
+        )
+
+    replace_index = map_file.loc[
+        map_file["custom_edit_url"] == "service_discovery_integrations"
+    ].index
+    if len(replace_index) > 0:
+        upper = map_file.iloc[: replace_index[0]]
+        lower = map_file.iloc[replace_index[0] + 1 :]
+
+        map_file = pd.concat(
+            [
+                upper,
+                service_discovery_entries.sort_values(
                     by=["learn_rel_path", "sidebar_label"],
                     key=lambda col: col.str.lower(),
                 ),


### PR DESCRIPTION
## Summary

- Adds `service_discovery_entries` DataFrame to `populate_integrations`
- Adds an `elif "/discovery/sdext/discoverer/" in normalized_file` path bucket so the 5 service discovery integration pages are classified correctly
- Adds a `service_discovery_integrations` sentinel replacement block (same pattern as `secretstore_integrations` and `flows_integrations`)

## Background

Service discovery integration pages live under `src/go/plugin/go.d/discovery/sdext/discoverer/*/integrations/*.md` in `netdata/netdata`. They have `learn_status: Published` and `learn_rel_path: "Collecting Metrics/Service Discovery"` but `populate_integrations` had no path match for them, so they fell into the `alerting_agent_entries` catch-all and were placed at the `agent_notifications_integrations` sentinel. They were landing at the correct URL by accident via `learn_rel_path`.

A companion PR in [netdata/netdata](https://github.com/netdata/netdata) adds `service_discovery` to the `integration_kind` enum in `map.schema.json` and updates `map.yaml` to use `integration_placeholder: service_discovery`.

## Test plan

- [ ] Ingest run places the 5 discoverer pages (Docker, SNMP, Net listeners, HTTP, k8s) under `docs/Collecting Metrics/Service Discovery/` — not under `docs/Alerts & Notifications/`
- [ ] `service_discovery_integrations` sentinel is replaced correctly in `generated_map.yaml`
- [ ] No regression on the agent notifications section (pages that previously fell into `else` for wrong reasons no longer do so)