### PR TITLE
Update Nedi markdown-it CDN dependency to 14.3.0

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -253,7 +253,7 @@ module.exports = {
         'data-reo-client-id': '8a197d1119ef2d4',
       },
       // Nedi dependencies (CDN) - async to avoid blocking other scripts
-      { src: 'https://cdn.jsdelivr.net/npm/markdown-it@14.2.0/dist/markdown-it.min.js', async: true },
+      { src: 'https://cdn.jsdelivr.net/npm/markdown-it@14.3.0/dist/markdown-it.min.js', async: true },
       { src: 'https://cdn.jsdelivr.net/npm/mermaid@11.16.0/dist/mermaid.min.js', async: true },
       { src: 'https://cdn.jsdelivr.net/npm/@viz-js/viz@3.28.0/dist/viz-global.js', async: true },
       { src: 'https://cdn.jsdelivr.net/npm/turndown@7.2.4/dist/turndown.js', async: true },


### PR DESCRIPTION
Updates the Nedi embed markdown-it CDN dependency from 14.2.0 to 14.3.0 to keep it synchronized with ai-agent and Cloud Frontend.