### PR TITLE
Fix non-deterministic ordering in ingest.py causing recurring YAML churn

### DIFF
--- a/ingest/ingest.py
+++ b/ingest/ingest.py
@@ -881,7 +881,8 @@ def populate_integrations(markdownFiles):
         [
             upper,
             authentication_entries.sort_values(
-                by=["learn_rel_path", "sidebar_label"], key=lambda col: col.str.lower()
+                by=["learn_rel_path", "sidebar_label", "custom_edit_url"],
+                key=lambda col: col.str.lower(),
             ),
             lower,
         ],
@@ -899,7 +900,8 @@ def populate_integrations(markdownFiles):
         [
             upper,
             collectors_entries.sort_values(
-                by=["learn_rel_path", "sidebar_label"], key=lambda col: col.str.lower()
+                by=["learn_rel_path", "sidebar_label", "custom_edit_url"],
+                key=lambda col: col.str.lower(),
             ),
             lower,
         ],
@@ -916,7 +918,8 @@ def populate_integrations(markdownFiles):
         [
             upper,
             secretstore_entries.sort_values(
-                by=["learn_rel_path", "sidebar_label"], key=lambda col: col.str.lower()
+                by=["learn_rel_path", "sidebar_label", "custom_edit_url"],
+                key=lambda col: col.str.lower(),
             ),
             lower,
         ],
@@ -934,7 +937,7 @@ def populate_integrations(markdownFiles):
             [
                 upper,
                 live_functions_entries.sort_values(
-                    by=["learn_rel_path", "sidebar_label"],
+                    by=["learn_rel_path", "sidebar_label", "custom_edit_url"],
                     key=lambda col: col.str.lower(),
                 ),
                 lower,
@@ -953,7 +956,8 @@ def populate_integrations(markdownFiles):
         [
             upper,
             alerting_agent_entries.sort_values(
-                by=["learn_rel_path", "sidebar_label"], key=lambda col: col.str.lower()
+                by=["learn_rel_path", "sidebar_label", "custom_edit_url"],
+                key=lambda col: col.str.lower(),
             ),
             lower,
         ],
@@ -970,7 +974,8 @@ def populate_integrations(markdownFiles):
         [
             upper,
             alerting_cloud_entries.sort_values(
-                by=["learn_rel_path", "sidebar_label"], key=lambda col: col.str.lower()
+                by=["learn_rel_path", "sidebar_label", "custom_edit_url"],
+                key=lambda col: col.str.lower(),
             ),
             lower,
         ],
@@ -988,7 +993,8 @@ def populate_integrations(markdownFiles):
         [
             upper,
             exporting_entries.sort_values(
-                by=["learn_rel_path", "sidebar_label"], key=lambda col: col.str.lower()
+                by=["learn_rel_path", "sidebar_label", "custom_edit_url"],
+                key=lambda col: col.str.lower(),
             ),
             lower,
         ],
@@ -1005,7 +1011,8 @@ def populate_integrations(markdownFiles):
         [
             upper,
             logs_entries.sort_values(
-                by=["learn_rel_path", "sidebar_label"], key=lambda col: col.str.lower()
+                by=["learn_rel_path", "sidebar_label", "custom_edit_url"],
+                key=lambda col: col.str.lower(),
             ),
             lower,
         ],
@@ -1023,7 +1030,7 @@ def populate_integrations(markdownFiles):
             [
                 upper,
                 flows_entries.sort_values(
-                    by=["learn_rel_path", "sidebar_label"],
+                    by=["learn_rel_path", "sidebar_label", "custom_edit_url"],
                     key=lambda col: col.str.lower(),
                 ),
                 lower,
@@ -1042,7 +1049,7 @@ def populate_integrations(markdownFiles):
             [
                 upper,
                 service_discovery_entries.sort_values(
-                    by=["learn_rel_path", "sidebar_label"],
+                    by=["learn_rel_path", "sidebar_label", "custom_edit_url"],
                     key=lambda col: col.str.lower(),
                 ),
                 lower,
@@ -1426,8 +1433,9 @@ def resolve_publish_path_collisions(publish_map):
 
 def fetch_markdown_from_repo(output_folder):
     """Return markdown file paths recursively, including dot-directories."""
-    return glob.glob(output_folder + "/**/*.md*", recursive=True) + glob.glob(
-        output_folder + "/.**/*.md*", recursive=True
+    return sorted(
+        glob.glob(output_folder + "/**/*.md*", recursive=True)
+        + glob.glob(output_folder + "/.**/*.md*", recursive=True)
     )
 
 
@@ -3366,7 +3374,7 @@ if __name__ == "__main__":
     temp_dict["learn_path"] = new_learn_paths_array
 
     df = pd.DataFrame.from_dict(temp_dict)
-    df.set_index("custom_edit_url")
+    df = df.sort_values(by="custom_edit_url").reset_index(drop=True)
     # Convert DataFrame to list of dicts and save as YAML
     redirect_data = df.to_dict(orient="records")
     with open("./ingest/one_commit_back_file-dict.yaml", "w", encoding="utf-8") as fh:

--- a/ingest/test_ingest_output_ordering.py
+++ b/ingest/test_ingest_output_ordering.py
@@ -1,0 +1,91 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+import pandas as pd
+
+
+INGEST_DIR = Path(__file__).resolve().parent
+if str(INGEST_DIR) not in sys.path:
+    sys.path.insert(0, str(INGEST_DIR))
+
+spec = importlib.util.spec_from_file_location("learn_ingest", INGEST_DIR / "ingest.py")
+ingest_module = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(ingest_module)
+
+
+WINDOWS_URL = (
+    "https://github.com/netdata/netdata/edit/master/"
+    "src/collectors/windows.plugin/integrations/system_statistics.md"
+)
+PROC_URL = (
+    "https://github.com/netdata/netdata/edit/master/"
+    "src/collectors/proc.plugin/integrations/system_statistics.md"
+)
+
+
+class TestGeneratedMapSortOrderIndependence(unittest.TestCase):
+    """windows.plugin and proc.plugin both publish a 'System statistics' doc
+    under the same learn_rel_path, so they tie on the first two sort keys.
+    Without a unique tiebreaker, their relative order depended on whichever
+    order they arrived in from glob.glob() (see PR #2937)."""
+
+    def _entries(self, first_url, second_url):
+        return pd.DataFrame(
+            [
+                {
+                    "custom_edit_url": first_url,
+                    "sidebar_label": "System statistics",
+                    "learn_rel_path": "Collecting Metrics/Collectors/Operating Systems",
+                },
+                {
+                    "custom_edit_url": second_url,
+                    "sidebar_label": "System statistics",
+                    "learn_rel_path": "Collecting Metrics/Collectors/Operating Systems",
+                },
+            ]
+        )
+
+    def _sorted_urls(self, entries):
+        sorted_entries = entries.sort_values(
+            by=["learn_rel_path", "sidebar_label", "custom_edit_url"],
+            key=lambda col: col.str.lower(),
+        )
+        return sorted_entries["custom_edit_url"].tolist()
+
+    def test_tied_rows_sort_independent_of_input_order(self):
+        windows_first = self._entries(WINDOWS_URL, PROC_URL)
+        proc_first = self._entries(PROC_URL, WINDOWS_URL)
+
+        self.assertEqual(
+            self._sorted_urls(windows_first), self._sorted_urls(proc_first)
+        )
+
+
+class TestOneCommitBackSortOrderIndependence(unittest.TestCase):
+    """one_commit_back_file-dict.yaml previously had no sort at all, so its
+    row order tracked raw dict-iteration order and churned almost entirely
+    on every ingest run."""
+
+    def _sorted_urls(self, custom_edit_urls, learn_paths):
+        df = pd.DataFrame(
+            {"custom_edit_url": custom_edit_urls, "learn_path": learn_paths}
+        )
+        df = df.sort_values(by="custom_edit_url").reset_index(drop=True)
+        return df["custom_edit_url"].tolist()
+
+    def test_rows_sort_independent_of_input_order(self):
+        urls = [WINDOWS_URL, PROC_URL, "https://github.com/netdata/netdata/edit/master/README.md"]
+        paths = ["/windows", "/proc", "/readme"]
+
+        forward = self._sorted_urls(urls, paths)
+        reversed_input = self._sorted_urls(list(reversed(urls)), list(reversed(paths)))
+
+        self.assertEqual(forward, reversed_input)
+        self.assertEqual(forward, sorted(urls))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- `ingest/generated_map.yaml` and `ingest/one_commit_back_file-dict.yaml` were reordering on every automated ingest run even when no real documentation content changed (see PR #2937, and the same pattern in #2915/#2917/#2919).
- Root cause: `fetch_markdown_from_repo()` returned unsorted `glob.glob()` output, and several `sort_values()` calls in `generated_map.yaml` generation had no tiebreaker for entries that share the same `learn_rel_path` and `sidebar_label` (e.g. `windows.plugin` and `proc.plugin` both publish a "System statistics" doc). `one_commit_back_file-dict.yaml` had no sort at all.
- Fix: sort the glob output at the source, add `custom_edit_url` (unique per source file) as a tiebreaker to all category sorts, and sort the redirect snapshot before writing it. Also removed a dead `df.set_index(...)` call whose result was discarded.

## Test plan
- [x] Added `ingest/test_ingest_output_ordering.py`, proving both sorts are independent of input row order (mirrors the existing `test_duplicate_keeper_is_independent_of_input_order` pattern in `test_integration_slug_collisions.py`).
- [x] `python3 -m unittest ingest.test_integration_slug_collisions ingest.test_logo_contrast ingest.test_ingest_output_ordering` — all pass.
- [x] Confirmed the new test fails against the old (pre-fix) 2-column sort key, proving it actually catches the bug.