### PR TITLE
Update Nedi CDN dependencies compatibly

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -216,7 +216,7 @@ module.exports = {
 	],
 	stylesheets: [
 		// Nedi embed styles
-			'https://nedi.netdata.cloud/ai-agent-ui.css?v=18',
+			'https://nedi.netdata.cloud/ai-agent-ui.css?v=19',
 		{
 			href: '/font/ibm-plex-sans-v8-latin-regular.woff2',
 			rel: 'preload',
@@ -253,14 +253,14 @@ module.exports = {
         'data-reo-client-id': '8a197d1119ef2d4',
       },
       // Nedi dependencies (CDN) - async to avoid blocking other scripts
-      { src: 'https://cdn.jsdelivr.net/npm/markdown-it@14.3.0/dist/markdown-it.min.js', async: true },
-      { src: 'https://cdn.jsdelivr.net/npm/mermaid@11.16.0/dist/mermaid.min.js', async: true },
-      { src: 'https://cdn.jsdelivr.net/npm/@viz-js/viz@3.28.0/dist/viz-global.js', async: true },
+      { src: 'https://cdn.jsdelivr.net/npm/markdown-it@15.0.0/dist/browser/markdown-it.umd.min.js', async: true },
+      { src: 'https://cdn.jsdelivr.net/npm/mermaid@11.16.1/dist/mermaid.min.js', async: true },
+      { src: 'https://cdn.jsdelivr.net/npm/@viz-js/viz@3.29.0/dist/viz-global.js', async: true },
       { src: 'https://cdn.jsdelivr.net/npm/turndown@7.2.4/dist/turndown.js', async: true },
       { src: 'https://cdn.jsdelivr.net/npm/@guyplusplus/turndown-plugin-gfm@1.0.7/dist/turndown-plugin-gfm.js', async: true },
       // Nedi embed
-      { src: 'https://nedi.netdata.cloud/ai-agent-public.js?v=18', async: true },
-      { src: 'https://nedi.netdata.cloud/ai-agent-ui.js?v=18', async: true },
+      { src: 'https://nedi.netdata.cloud/ai-agent-public.js?v=19', async: true },
+      { src: 'https://nedi.netdata.cloud/ai-agent-ui.js?v=19', async: true },
     ],
     headTags: [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
 				"axios": "^1.18.1",
 				"clsx": "^2.1.1",
 				"dotenv": "^17.2.3",
-				"mermaid": "^11.16.0",
+				"mermaid": "^11.16.1",
 				"postcss": "^8.5.23",
 				"postcss-import": "^16.1.1",
 				"postcss-nesting": "^14.0.0",
@@ -18454,9 +18454,9 @@
 			}
 		},
 		"node_modules/mermaid": {
-			"version": "11.16.0",
-			"resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.0.tgz",
-			"integrity": "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==",
+			"version": "11.16.1",
+			"resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.1.tgz",
+			"integrity": "sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==",
 			"license": "MIT",
 			"dependencies": {
 				"@braintree/sanitize-url": "^7.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
 				"postcss-loader": "^8.2.0",
 				"postcss-preset-env": "^11.1.2",
 				"tailwindcss": "^4.1.18",
+				"vite": "^8.1.5",
 				"vitest": "^4.1.8"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"axios": "^1.18.1",
 		"clsx": "^2.1.1",
 		"dotenv": "^17.2.3",
-		"mermaid": "^11.16.0",
+		"mermaid": "^11.16.1",
 		"postcss": "^8.5.23",
 		"postcss-import": "^16.1.1",
 		"postcss-nesting": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
 		"postcss-loader": "^8.2.0",
 		"postcss-preset-env": "^11.1.2",
 		"tailwindcss": "^4.1.18",
+		"vite": "^8.1.5",
 		"vitest": "^4.1.8"
 	},
 	"browserslist": {

--- a/src/components/Nedi/index.js
+++ b/src/components/Nedi/index.js
@@ -1,6 +1,8 @@
 import { useRef, useEffect } from 'react';
 import { useColorMode } from '@docusaurus/theme-common';
 
+import { ensureMarkdownItCompatibility } from './markdownItCompatibility';
+
 const NEDI_ENDPOINT = 'https://nedi.netdata.cloud';
 const PERSISTENT_ID = 'nedi-persistent';
 const SCROLL_KEY = 'nedi-scroll-y';
@@ -80,6 +82,7 @@ export default function Nedi() {
     const boot = () => {
       if (!mountRef.current) return;
       if (typeof window.AiAgentChatUI === 'undefined') return false;
+      if (!ensureMarkdownItCompatibility(window)) return false;
 
       const nediEl = getOrCreateNedi(colorMode);
 

--- a/src/components/Nedi/markdownItCompatibility.js
+++ b/src/components/Nedi/markdownItCompatibility.js
@@ -1,0 +1,20 @@
+const compatibleConstructors = new WeakSet();
+
+const enableFuzzyLinks = (renderer) => {
+  renderer?.linkify?.set?.({ fuzzyLink: true });
+  return renderer;
+};
+
+export const ensureMarkdownItCompatibility = (browserWindow = window) => {
+  const markdownIt = browserWindow.markdownit;
+  if (typeof markdownIt !== 'function') return false;
+  if (compatibleConstructors.has(markdownIt)) return true;
+
+  const compatibleMarkdownIt = new Proxy(markdownIt, {
+    apply: (target, thisArg, args) => enableFuzzyLinks(Reflect.apply(target, thisArg, args)),
+    construct: (target, args, newTarget) => enableFuzzyLinks(Reflect.construct(target, args, newTarget)),
+  });
+  compatibleConstructors.add(compatibleMarkdownIt);
+  browserWindow.markdownit = compatibleMarkdownIt;
+  return true;
+};

--- a/src/components/Nedi/markdownItCompatibility.test.js
+++ b/src/components/Nedi/markdownItCompatibility.test.js
@@ -1,0 +1,39 @@
+import { ensureMarkdownItCompatibility } from './markdownItCompatibility';
+
+const createMarkdownIt = () => {
+  const calls = [];
+  const markdownIt = () => ({
+    linkify: { set: (options) => calls.push(options) },
+  });
+  markdownIt.utils = { escapeHtml: () => {} };
+  return { calls, markdownIt };
+};
+
+describe('Nedi markdown-it compatibility', () => {
+  test('enables fuzzy links on every renderer instance', () => {
+    const { calls, markdownIt } = createMarkdownIt();
+    const browserWindow = { markdownit: markdownIt };
+
+    expect(ensureMarkdownItCompatibility(browserWindow)).toBe(true);
+    browserWindow.markdownit({ linkify: true });
+    browserWindow.markdownit({ linkify: true });
+
+    expect(calls).toEqual([{ fuzzyLink: true }, { fuzzyLink: true }]);
+  });
+
+  test('is idempotent and preserves constructor properties', () => {
+    const { markdownIt } = createMarkdownIt();
+    const browserWindow = { markdownit: markdownIt };
+
+    ensureMarkdownItCompatibility(browserWindow);
+    const wrapped = browserWindow.markdownit;
+    ensureMarkdownItCompatibility(browserWindow);
+
+    expect(browserWindow.markdownit).toBe(wrapped);
+    expect(browserWindow.markdownit.utils).toBe(markdownIt.utils);
+  });
+
+  test('waits until markdown-it is available', () => {
+    expect(ensureMarkdownItCompatibility({})).toBe(false);
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,11 +1,23 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import path from 'path';
+import { transformWithOxc } from 'vite';
 
 const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const jsxInJavaScript = {
+  name: 'learn-jsx-in-javascript',
+  enforce: 'pre',
+  async transform(code, id) {
+    if (!/[/\\]src[/\\].*\.js(?:$|\?)/.test(id)) return null;
+    return transformWithOxc(code, id, {
+      lang: 'jsx',
+      jsx: { runtime: 'automatic' },
+    });
+  },
+};
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [jsxInJavaScript, react()],
 
   test: {
     // Use jsdom for DOM simulation
@@ -55,16 +67,9 @@ export default defineConfig({
     },
   },
 
-  esbuild: {
-    // Treat .js and .jsx files as JSX
-    loader: 'jsx',
-    include: /src\/.*\.jsx?$/,
-    exclude: [],
-  },
-
   optimizeDeps: {
-    esbuildOptions: {
-      loader: {
+    rolldownOptions: {
+      moduleTypes: {
         '.js': 'jsx',
         '.jsx': 'jsx',
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -13843,7 +13843,7 @@ vimeo-video-element@^1.6.1:
   dependencies:
     "@vimeo/player" "2.29.0"
 
-"vite@^6.0.0 || ^7.0.0 || ^8.0.0":
+"vite@^6.0.0 || ^7.0.0 || ^8.0.0", vite@^8.1.5:
   version "8.1.5"
   resolved "https://registry.yarnpkg.com/vite/-/vite-8.1.5.tgz#ccffce3ee487b1886223b24ebb27b91674827d30"
   integrity sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -9816,10 +9816,10 @@ merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-mermaid@>=11.6.0, mermaid@^11.16.0:
-  version "11.16.0"
-  resolved "https://registry.npmmirror.com/mermaid/-/mermaid-11.16.0.tgz#dc946bc84bde9d093ba14940d49df1d9f7d8c32f"
-  integrity sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==
+mermaid@>=11.6.0, mermaid@^11.16.1:
+  version "11.16.1"
+  resolved "https://registry.npmjs.org/mermaid/-/mermaid-11.16.1.tgz#57ae2342f6c45b967113b04c9258430bdd057ee8"
+  integrity sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==
   dependencies:
     "@braintree/sanitize-url" "^7.1.2"
     "@iconify/utils" "^3.0.2"


### PR DESCRIPTION
## Summary

- update the Nedi browser dependencies to markdown-it 15.0.0, Mermaid 11.16.1, and Viz 3.29.0
- advance the Nedi asset cache key to v19
- wrap markdown-it before Nedi construction so this consumer remains compatible with both old and new Nedi releases
- make Vitest/Vite 8 parse the repository's JSX-in-`.js` source through Vite's Oxc transform

## Independent deployment contract

This is the Learn consumer change for ai-agent SOW-0147. It preserves all rollout combinations:

- old Learn with new Nedi
- new Learn with old Nedi
- old/old baseline
- new/new upgraded path

## Validation

- focused Nedi compatibility test: 3/3 passed
- full Vitest suite: 262/262 passed
- production Docusaurus build with its configured 8 GiB Node heap: passed
- Yarn frozen-lockfile install: passed
