### PR TITLE
Prevent partial Learn ingest publication

### DIFF
--- a/.github/workflows/ingest.yml
+++ b/.github/workflows/ingest.yml
@@ -64,15 +64,15 @@ jobs:
           echo "$OUTPUT" >> $GITHUB_OUTPUT
           echo "$EOF" >> $GITHUB_OUTPUT
           
-          # Check if there are broken links (exit code 1 means broken links found)
-          if [ $EXIT_CODE -eq 1 ]; then
+          # Accept only final states emitted after every ingest stage completed.
+          RESULT=$(printf '%s' "$OUTPUT" | python ingest/classify_ingest_result.py "$EXIT_CODE")
+          if [ "$RESULT" = "broken_links" ]; then
             echo "has_broken_links=true" >> $GITHUB_OUTPUT
-          elif [ $EXIT_CODE -eq 0 ]; then
+          elif [ "$RESULT" = "success" ]; then
             echo "has_broken_links=false" >> $GITHUB_OUTPUT
           else
-            echo "has_broken_links=false" >> $GITHUB_OUTPUT
-            echo "Ingest failed with non-broken-links error (exit code: $EXIT_CODE)"
-            exit $EXIT_CODE
+            echo "Unexpected ingest classification: $RESULT"
+            exit 2
           fi
 
           # Don't fail the workflow on broken links - we'll create an issue instead
@@ -108,7 +108,24 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const output = `${{ steps.ingest.outputs.output }}`;
-            const assignees = '${{ env.BROKEN_LINKS_ASSIGNEES }}'.split(',').map(s => s.trim()).filter(s => s);
+            const configuredAssignees = '${{ env.BROKEN_LINKS_ASSIGNEES }}'.split(',').map(s => s.trim()).filter(s => s);
+            const assignees = [];
+            for (const assignee of configuredAssignees) {
+              try {
+                await github.request('GET /repos/{owner}/{repo}/assignees/{assignee}', {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  assignee,
+                });
+                assignees.push(assignee);
+              } catch (error) {
+                if (error.status === 404) {
+                  console.warn(`Skipping unavailable issue assignee: ${assignee}`);
+                  continue;
+                }
+                throw error;
+              }
+            }
             const today = new Date().toISOString().split('T')[0];
             
             // Build issue body with the script output

--- a/ingest/classify_ingest_result.py
+++ b/ingest/classify_ingest_result.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+"""Classify a completed Learn ingest without confusing crashes with link debt."""
+
+import argparse
+import sys
+
+
+SUCCESS_MARKER = "OPERATION FINISHED - SUCCESS (exit code: 0)"
+BROKEN_LINK_MARKER = "OPERATION FINISHED - FAILURE (exit code: 1)"
+BROKEN_LINK_REASON = "Broken links detected matching failure criteria"
+
+
+class IncompleteIngestError(RuntimeError):
+    """Raised when process status and final ingest evidence do not agree."""
+
+
+def classify_result(exit_code, output):
+    success_count = output.count(SUCCESS_MARKER)
+    broken_count = output.count(BROKEN_LINK_MARKER)
+    reason_count = output.count(BROKEN_LINK_REASON)
+
+    if exit_code == 0 and (success_count, broken_count, reason_count) == (1, 0, 0):
+        return "success"
+    if exit_code == 1 and (success_count, broken_count, reason_count) == (0, 1, 1):
+        return "broken_links"
+
+    raise IncompleteIngestError(
+        "Ingest did not reach one recognized final state "
+        f"(exit={exit_code}, success_markers={success_count}, "
+        f"broken_link_markers={broken_count}, broken_link_reasons={reason_count})"
+    )
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("exit_code", type=int)
+    args = parser.parse_args(argv)
+    output = sys.stdin.read()
+    try:
+        result = classify_result(args.exit_code, output)
+    except IncompleteIngestError as error:
+        print(error, file=sys.stderr)
+        return 2
+    print(result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ingest/ingest.py
+++ b/ingest/ingest.py
@@ -199,6 +199,24 @@ def _validate_docs_tree(docs_root):
     return root
 
 
+def _child_directories(directory):
+    """Return real child directories without relying on glob suffix behavior."""
+    directory = _require_regular_directory(directory)
+    children = []
+    with os.scandir(directory) as entries:
+        for entry in entries:
+            path = Path(entry.path)
+            if entry.is_symlink():
+                raise UnsafeFilesystemPathError(f"Refusing symbolic link: {path}")
+            if entry.is_dir(follow_symlinks=False):
+                children.append(path)
+            elif not entry.is_file(follow_symlinks=False):
+                raise UnsafeFilesystemPathError(
+                    f"Refusing non-regular filesystem entry: {path}"
+                )
+    return sorted(children, key=lambda path: path.name)
+
+
 def _validate_path_under_root(
     docs_root, path, *, allow_missing_leaf=False, expected="file"
 ):
@@ -3494,7 +3512,7 @@ def get_dir_make_file_and_recurse(
                     encoding="utf-8",
                 )
 
-        for subdir in sorted(Path(directory).glob("*/")):
+        for subdir in _child_directories(directory):
             get_dir_make_file_and_recurse(
                 subdir,
                 overwrite_generated,

--- a/ingest/test_ingest_directory_traversal.py
+++ b/ingest/test_ingest_directory_traversal.py
@@ -1,0 +1,43 @@
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+INGEST_DIR = Path(__file__).resolve().parent
+spec = importlib.util.spec_from_file_location("learn_ingest", INGEST_DIR / "ingest.py")
+ingest = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(ingest)
+
+
+class IngestDirectoryTraversalTests(unittest.TestCase):
+    def test_child_directories_exclude_files_and_are_sorted(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "Zulu").mkdir()
+            (root / "Alpha").mkdir()
+            (root / "Page.mdx").write_text("# Page\n", encoding="utf-8")
+
+            self.assertEqual(
+                [path.name for path in ingest._child_directories(root)],
+                ["Alpha", "Zulu"],
+            )
+
+    def test_child_directories_reject_directory_symlinks(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            outside = root / "outside"
+            outside.mkdir()
+            docs = root / "docs"
+            docs.mkdir()
+            (docs / "Linked").symlink_to(outside, target_is_directory=True)
+
+            with self.assertRaisesRegex(
+                ingest.UnsafeFilesystemPathError, "symbolic link"
+            ):
+                ingest._child_directories(docs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ingest/test_ingest_workflow.py
+++ b/ingest/test_ingest_workflow.py
@@ -1,0 +1,52 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+INGEST_DIR = Path(__file__).resolve().parent
+spec = importlib.util.spec_from_file_location(
+    "classify_ingest_result", INGEST_DIR / "classify_ingest_result.py"
+)
+classifier = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(classifier)
+
+
+class IngestWorkflowClassificationTests(unittest.TestCase):
+    def test_accepts_completed_success(self):
+        output = f"work\n{classifier.SUCCESS_MARKER}\n"
+        self.assertEqual(classifier.classify_result(0, output), "success")
+
+    def test_accepts_completed_broken_link_run(self):
+        output = (
+            f"work\n{classifier.BROKEN_LINK_MARKER}\n"
+            f"{classifier.BROKEN_LINK_REASON}\n"
+        )
+        self.assertEqual(classifier.classify_result(1, output), "broken_links")
+
+    def test_rejects_operational_crash_with_exit_one(self):
+        output = "Traceback (most recent call last):\nUnsafeFilesystemPathError\n"
+        with self.assertRaises(classifier.IncompleteIngestError):
+            classifier.classify_result(1, output)
+
+    def test_rejects_success_without_completion_marker(self):
+        with self.assertRaises(classifier.IncompleteIngestError):
+            classifier.classify_result(0, "work stopped early\n")
+
+    def test_rejects_conflicting_completion_markers(self):
+        output = (
+            f"{classifier.SUCCESS_MARKER}\n"
+            f"{classifier.BROKEN_LINK_MARKER}\n"
+            f"{classifier.BROKEN_LINK_REASON}\n"
+        )
+        with self.assertRaises(classifier.IncompleteIngestError):
+            classifier.classify_result(1, output)
+
+    def test_rejects_other_exit_codes(self):
+        output = f"{classifier.SUCCESS_MARKER}\n"
+        with self.assertRaises(classifier.IncompleteIngestError):
+            classifier.classify_result(2, output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/seo/generatedOutputBoundary.test.js
+++ b/src/seo/generatedOutputBoundary.test.js
@@ -104,4 +104,26 @@ describe('generated output ownership', () => {
     expect(workflow).toContain('- ingest/**');
     expect(workflow).toContain('- static.toml');
   });
+
+  it('fails closed before publishing incomplete ingest output', () => {
+    const workflow = readFileSync(
+      path.join(repositoryRoot, '.github/workflows/ingest.yml'),
+      'utf8',
+    );
+    const classifier = 'python ingest/classify_ingest_result.py "$EXIT_CODE"';
+    expect(workflow).toContain(classifier);
+    expect(workflow.indexOf(classifier)).toBeLessThan(
+      workflow.indexOf('- name: Create pull request'),
+    );
+  });
+
+  it('checks broken-link assignee eligibility before issue publication', () => {
+    const workflow = readFileSync(
+      path.join(repositoryRoot, '.github/workflows/ingest.yml'),
+      'utf8',
+    );
+    expect(workflow).toContain(
+      'GET /repos/{owner}/{repo}/assignees/{assignee}',
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- enumerate generated-content child directories without the Python-version-sensitive trailing-slash glob
- reject incomplete or crashed ingest output before checksum and pull-request publication
- filter unavailable broken-link issue assignees through the GitHub eligibility endpoint
- add focused traversal, completion-state, publication-order, and assignee checks

## Incident

Learn run 31893353719 crashed during generated-output reconciliation, was misclassified as broken links, and updated automated PR #2979 with partial output. The issue-reporting step then failed on an unavailable assignee.

## Validation

- 49 Python ingest tests
- 386 Vitest tests against the current accepted built corpus
- 64 IndexNow tests
- 4 site-build-gate tests
- focused classifier CLI and workflow-order checks
- actionlint syntax validation; existing action-version and shellcheck advisories are unchanged
- no generated documentation, generated map, sidebar state, redirect, content, or rendered-output changes

After this hotfix is merged, rerun ingestion and review the replacement output in #2979. Do not merge the current #2979 head.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ingest result handling to distinguish successful runs from broken-link outcomes and unexpected failures.
  * Prevented unsafe filesystem entries, including directory symlinks, from being processed.
  * Validated issue assignees before creating or updating broken-link issues, while surfacing unexpected API errors.

* **Tests**
  * Added coverage for ingest classifications, directory traversal safety, workflow behavior, and assignee validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->