### PR TITLE
Fix rendered redirect-source link verification

### DIFF
--- a/scripts/verify-rendered-links.js
+++ b/scripts/verify-rendered-links.js
@@ -1,5 +1,6 @@
 const fs = require('node:fs');
 const path = require('node:path');
+const {parse} = require('parse5');
 
 const HOST = 'learn.netdata.cloud';
 
@@ -88,17 +89,25 @@ function routeForFile(publishDir, filename) {
 function renderedInternalLinks(html, sourceRoute, host = HOST) {
   const source = new URL(sourceRoute, `https://${host}/`);
   const links = [];
-  // Docusaurus emits quoted href attributes. Keeping this boundary explicit avoids
-  // pretending this small verifier is a general-purpose HTML parser.
-  for (const match of html.matchAll(/<a\b[^>]*\bhref\s*=\s*(?:"([^"]*)"|'([^']*)')[^>]*>/gi)) {
-    const href = decodeHtml(match[1] ?? match[2] ?? '').trim();
-    if (!href || href.startsWith('#')) continue;
-    try {
-      const target = new URL(href, source);
-      if (!['http:', 'https:'].includes(target.protocol) || target.hostname !== host) continue;
-      links.push({href, pathname: normalizePathname(target.pathname)});
-    } catch {
-      // Invalid hrefs belong to the broader link checker, not this exact redirect gate.
+  const stack = [parse(html)];
+  while (stack.length) {
+    const node = stack.pop();
+    if (node.nodeName === 'a') {
+      const hrefAttribute = node.attrs?.find((attribute) => attribute.name === 'href');
+      const href = hrefAttribute?.value.trim();
+      if (href && !href.startsWith('#')) {
+        try {
+          const target = new URL(href, source);
+          if (['http:', 'https:'].includes(target.protocol) && target.hostname === host) {
+            links.push({href, pathname: normalizePathname(target.pathname)});
+          }
+        } catch {
+          // Invalid hrefs belong to the broader link checker, not this exact redirect gate.
+        }
+      }
+    }
+    for (let index = (node.childNodes?.length ?? 0) - 1; index >= 0; index -= 1) {
+      stack.push(node.childNodes[index]);
     }
   }
   return links;
@@ -126,6 +135,9 @@ function verifyRenderedLinks(
       else if (entry.isFile() && entry.name.endsWith('.html')) htmlFiles.push(filename);
     }
   }
+  if (htmlFiles.length === 0) {
+    throw new Error(`Rendered link verification found no HTML files in ${publishDir}`);
+  }
 
   const violations = [];
   let internalLinks = 0;
@@ -143,6 +155,11 @@ function verifyRenderedLinks(
         violations.push({sourceRoute, href: link.href, redirectSource});
       }
     }
+  }
+  if (internalLinks === 0) {
+    throw new Error(
+      `Rendered link verification found zero internal links across ${htmlFiles.length} HTML files`,
+    );
   }
   if (violations.length) {
     const detail = violations

--- a/src/seo/renderedLinks.test.js
+++ b/src/seo/renderedLinks.test.js
@@ -90,6 +90,12 @@ describe('rendered redirect-source link verifier', () => {
       .toThrow(/Rendered links target redirect sources/);
   });
 
+  it('fails on an unquoted link to an exact redirect source', async () => {
+    const fixturePaths = await fixture('<a href=/docs/old/>unquoted redirect source</a>');
+    expect(() => verifyRenderedLinks(fixturePaths.publishDir, fixturePaths.netlifyPath))
+      .toThrow(/Rendered links target redirect sources/);
+  });
+
   it('allows only an explicitly configured root entrypoint redirect', async () => {
     const fixturePaths = await fixture('<a href="/">documentation entrypoint</a>', {
       includeRoot: true,
@@ -135,10 +141,46 @@ describe('rendered redirect-source link verifier', () => {
       .toMatchObject({wildcardRedirectSources: 1});
   });
 
-  it('pins the quoted href boundary used by Docusaurus output', () => {
-    const html = '<a href="/quoted">quoted</a><a href=/unquoted>unquoted</a>';
+  it('parses quoted, unquoted, and character-reference href attributes', () => {
+    const html =
+      '<a href="/quoted">quoted</a><a href=/unquoted>unquoted</a>' +
+      '<a href="/character-&#114;ef">character reference</a>';
     expect(renderedInternalLinks(html, '/docs/source')).toEqual([
       {href: '/quoted', pathname: '/quoted'},
+      {href: '/unquoted', pathname: '/unquoted'},
+      {href: '/character-ref', pathname: '/character-ref'},
     ]);
+  });
+
+  it('uses parser-defined first-attribute semantics for duplicate hrefs', () => {
+    expect(
+      renderedInternalLinks(
+        '<a href=/docs/old/ href=/docs/new>duplicate href</a>',
+        '/docs/source',
+      ),
+    ).toEqual([{href: '/docs/old/', pathname: '/docs/old/'}]);
+  });
+
+  it('ignores anchor-shaped text outside parsed elements', () => {
+    const html =
+      '<script>const sample = \'<a href="/docs/old/">not markup</a>\';</script>' +
+      '<!-- <a href=/docs/old/>not markup either</a> -->';
+    expect(renderedInternalLinks(html, '/docs/source')).toEqual([]);
+  });
+
+  it('fails closed when a rendered site has no internal links', async () => {
+    const fixturePaths = await fixture('<a href="https://example.com/">external only</a>');
+    expect(() => verifyRenderedLinks(fixturePaths.publishDir, fixturePaths.netlifyPath))
+      .toThrow(/zero internal links/);
+  });
+
+  it('fails closed when the publish directory has no HTML files', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'learn-rendered-links-empty-'));
+    temporaryDirectories.push(root);
+    const publishDir = path.join(root, 'build');
+    const netlifyPath = path.join(root, 'netlify.toml');
+    await fs.mkdir(publishDir, {recursive: true});
+    await fs.writeFile(netlifyPath, '[[redirects]]\nfrom="/docs/old/"\nto="/docs/new"\n');
+    expect(() => verifyRenderedLinks(publishDir, netlifyPath)).toThrow(/no HTML files/);
   });
 });


### PR DESCRIPTION
## Summary

- parse rendered anchors with the existing pinned HTML parser instead of a quoted-attribute regex
- cover quoted, unquoted, character-reference, duplicate-attribute, script/comment, and empty-scan boundaries
- fail closed when no HTML files or no internal links are scanned

## Validation

- 14 focused rendered-link tests
- 391 Vitest tests
- 64 IndexNow tests
- 4 C8 integration tests
- exact Node 22.14.0/npm 10.9.2 production build
- 821,342 internal links across 1,984 HTML files; zero redirect-source violations
- zero noindex; RUM, redirect graph, title, H1, sitemap, and C8 gates pass

No generated documentation is included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes rendered redirect-source link verification by replacing a quoted-attribute regex with the pinned HTML parser. This removes false positives from scripts/comments, supports unquoted and character-reference hrefs, and now fails closed when no HTML files or no internal links are found.

- Switches to `parse5` and walks nodes to collect anchor hrefs; applies first-attribute semantics for duplicates; decodes character references; still ignores fragments and off-site URLs and normalizes pathnames.
- Adds fail-closed errors for zero HTML files and zero internal links; previously these cases passed without checking.
- Expands tests for quoted/unquoted/character-reference hrefs, duplicate attributes, and script/comment boundaries.

<sup>Written for commit 21fd114235c49eb5a1a91403aba67c02a9bf0bda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/learn/pull/2984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

