### PR TITLE
Exclude Ask Nedi from the sitemap

### DIFF
--- a/config/seo-remediation-contract.json
+++ b/config/seo-remediation-contract.json
@@ -96,11 +96,11 @@
     "new_agent_descriptions_exact": 40,
     "terminal_description_ellipses": 0,
     "tests": {
-      "python_ingest": 41,
+      "python_ingest": 54,
       "mdx_escaping": 54,
-      "vitest_files": 25,
-      "vitest_tests": 368,
-      "indexnow": 63,
+      "vitest_files": 27,
+      "vitest_tests": 394,
+      "indexnow": 64,
       "canonical_c8": 4,
       "exact_agent_source": 76
     },
@@ -113,14 +113,14 @@
       "node_heap_mib": 8192
     },
     "production_builds": 2,
-    "build_files": 4166,
-    "build_manifest_sha256": "e859b0cee5dae7c463b876ebb0059f42b010c26437280ee3bde641428a06cfde",
+    "build_files": 4157,
+    "build_manifest_sha256": "fefdc6d0b9f5cef71b1e1127f32b84f30391673e106e006bb6e1ac79a69b5912",
     "byte_identical": true,
     "rendered_html_files": 1984,
-    "sitemap_urls": 1979,
-    "sitemap_urls_with_lastmod": 1979,
-    "distinct_lastmod_timestamps": 46,
-    "unique_rendered_titles": 1979,
+    "sitemap_urls": 1978,
+    "sitemap_urls_with_lastmod": 1978,
+    "distinct_lastmod_timestamps": 45,
+    "unique_rendered_titles": 1978,
     "functional_routes_with_exactly_one_h1": 1,
     "rendered_internal_links": 821342,
     "noindex_directives": 0,
@@ -139,7 +139,7 @@
     "push_deploy_live_provider_or_macos_actions": 0
   },
   "implementation_plan": [
-    "Replace the client-only root redirect with a permanent source-owned Netlify redirect to Ask Nedi, keep the root out of rendered output and the sitemap, add the missing blog heading, and validate both route purposes without applying content-page rules to redirects.",
+    "Replace the client-only root redirect with a permanent source-owned Netlify redirect to Ask Nedi, keep both the root and the robots-disallowed Ask Nedi application route out of the sitemap, add the missing blog heading, and validate both route purposes without applying content-page rules to redirects.",
     "Keep sitemap exclusion separate from robots indexability, emit zero noindex directives across every rendered HTML route, and restore all public libnetdata references to the sitemap.",
     "Persist upstream sidebar ordering with exact source and corpus provenance, then make full ingest and grid-only recovery use one reconciliation and finalization path.",
     "Paginate every generated integration grid above the 175-card page capacity, emit every card exactly once, and safely reconcile grid creation, removal, and page-count transitions.",
@@ -162,12 +162,12 @@
     {
       "id": "root-redirect-and-blog-rendering",
       "contract": "The root route preserves its established Ask Nedi product journey as a permanent one-hop Netlify redirect. No root HTML artifact may shadow it and the root remains outside the sitemap. The navbar and other callers use stable / rather than knowing the current destination. The navbar uses Docusaurus' pathname escape with a same-window target so clicking it performs a normal document request through Netlify instead of client-side routing or opening another tab. The functional blog page has exactly one H1 while remaining sitemap-excluded.",
-      "acceptance": "The redirect graph requires / to terminate at the rendered /docs/ask-nedi route, the build contains no root index.html, the sitemap excludes /, the rendered navbar logo links to / using the pathname escape and target _self, and blog renders exactly one H1. The corrected Deploy Preview returns HTTP 301 with Location /docs/ask-nedi, a same-window browser logo click follows that edge redirect, and the destination returns HTTP 200."
+      "acceptance": "The redirect graph requires / to terminate at the rendered /docs/ask-nedi route, the build contains no root index.html, the sitemap excludes both / and /docs/ask-nedi, static/robots.txt continues to disallow /docs/ask-nedi, the rendered navbar logo links to / using the pathname escape and target _self, and blog renders exactly one H1. The corrected Deploy Preview returns HTTP 301 with Location /docs/ask-nedi, a same-window browser logo click follows that edge redirect, and the destination returns HTTP 200."
     },
     {
       "id": "zero-noindex-sitemap-separation",
-      "contract": "Public routes never emit a noindex robots directive. Sitemap exclusion is a separate discovery choice: blog and search remain excluded, the obsolete Ask Netdata path is a permanent redirect rather than an HTML route, and all current self-canonical libnetdata references remain included and indexable.",
-      "acceptance": "Every rendered HTML file contains zero noindex directives; all current libnetdata routes occur exactly once in the sitemap; blog, search, and the redirected Ask Netdata path remain absent from it."
+      "contract": "Public routes never emit a noindex robots directive. Sitemap exclusion is a separate discovery choice: blog and search remain excluded, the obsolete Ask Netdata path is a permanent redirect rather than an HTML route, the crawler-blocked Ask Nedi application remains outside automated sitemap submission, and all current self-canonical libnetdata references remain included and indexable.",
+      "acceptance": "Every rendered HTML file contains zero noindex directives; every sitemap URL is crawlable under the wildcard robots.txt policy; all current libnetdata routes occur exactly once in the sitemap; blog, search, the redirected Ask Netdata path, and the robots-disallowed Ask Nedi application remain absent from it."
     },
     {
       "id": "grid-recovery-equivalence",
@@ -217,7 +217,7 @@
     {
       "id": "manual-cloudflare-web-analytics",
       "contract": "Docusaurus' shared HTML script configuration emits one defer type=module Cloudflare beacon with the approved zone-level public token. The source remains unversioned and has no integrity attribute; the token is public and no Cloudflare credential enters the repository. The API console and OAuth callback are explicit security-sensitive exceptions and contain no third-party script code.",
-      "acceptance": "Every normal rendered HTML file contains exactly one executable manual beacon and token. Equivalent Cloudflare host/path resource spellings count as the same beacon regardless of DNS-root trailing dot, HTTP-to-HTTPS redirect, or served HTTPS port; the sole allowed beacon still requires the exact approved URL. api.html and oauth2-redirect.html contain zero third-party script code and fail closed on browser-active script, module, nested-document, shadow-DOM, URL-base, preload, import-map, and policy bypasses. The obsolete Ask Netdata compatibility document does not exist; its one-hop permanent redirect targets the rendered Ask Nedi route. The zero-noindex and sitemap contracts remain unchanged."
+      "acceptance": "Every normal rendered HTML file contains exactly one executable manual beacon and token. Equivalent Cloudflare host/path resource spellings count as the same beacon regardless of DNS-root trailing dot, HTTP-to-HTTPS redirect, or served HTTPS port; the sole allowed beacon still requires the exact approved URL. api.html and oauth2-redirect.html contain zero third-party script code and fail closed on browser-active script, module, nested-document, shadow-DOM, URL-base, preload, import-map, and policy bypasses. The obsolete Ask Netdata compatibility document does not exist; its one-hop permanent redirect targets the rendered Ask Nedi route. The zero-noindex and robots-safe sitemap contracts remain enforced."
     },
     {
       "id": "exact-final-agent-source-ingest",

--- a/scripts/verify-rendered-indexability.js
+++ b/scripts/verify-rendered-indexability.js
@@ -1,7 +1,10 @@
 const fs = require('node:fs');
 const path = require('node:path');
 
+const {sitemapUrls} = require('./verify-rendered-titles');
+
 const ROBOTS_NAMES = new Set(['robots', 'googlebot', 'bingbot']);
+const SITE_HOST = 'learn.netdata.cloud';
 
 function attributes(tag) {
   const result = new Map();
@@ -48,6 +51,73 @@ function noindexResponseHeaders(netlifyToml) {
   return directives;
 }
 
+function wildcardRobotsRules(robotsText) {
+  const rules = [];
+  let userAgents = [];
+  let rulesStarted = false;
+
+  for (const rawLine of robotsText.split(/\r?\n/)) {
+    const line = rawLine.replace(/#.*$/, '').trim();
+    if (!line) {
+      userAgents = [];
+      rulesStarted = false;
+      continue;
+    }
+
+    const separator = line.indexOf(':');
+    if (separator < 0) continue;
+    const field = line.slice(0, separator).trim().toLowerCase();
+    const value = line.slice(separator + 1).trim();
+
+    if (field === 'user-agent') {
+      if (rulesStarted) {
+        userAgents = [];
+        rulesStarted = false;
+      }
+      userAgents.push(value.toLowerCase());
+      continue;
+    }
+
+    if (field !== 'allow' && field !== 'disallow') continue;
+    rulesStarted = true;
+    if (!userAgents.includes('*') || !value) continue;
+    rules.push({allow: field === 'allow', pattern: value});
+  }
+
+  return rules;
+}
+
+function robotsRuleRegex(pattern) {
+  const endAnchored = pattern.endsWith('$');
+  const body = endAnchored ? pattern.slice(0, -1) : pattern;
+  const source = body
+    .split('*')
+    .map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('.*');
+  return new RegExp(`^${source}${endAnchored ? '$' : ''}`);
+}
+
+function wildcardRobotsAllows(pathname, rules) {
+  const matches = rules
+    .filter((rule) => robotsRuleRegex(rule.pattern).test(pathname))
+    .map((rule) => ({
+      ...rule,
+      specificity: rule.pattern.length,
+    }));
+
+  if (!matches.length) return true;
+  const mostSpecific = Math.max(...matches.map((rule) => rule.specificity));
+  return matches.some((rule) => rule.specificity === mostSpecific && rule.allow);
+}
+
+function sitemapRobotsViolations(sitemapXml, robotsText, host = SITE_HOST) {
+  const rules = wildcardRobotsRules(robotsText);
+  return sitemapUrls(sitemapXml, host).filter((value) => {
+    const url = new URL(value);
+    return !wildcardRobotsAllows(`${url.pathname}${url.search}`, rules);
+  });
+}
+
 function regularFile(filename) {
   const stat = fs.lstatSync(filename);
   if (stat.isSymbolicLink()) throw new Error(`Rendered output contains a symbolic link: ${filename}`);
@@ -72,7 +142,12 @@ function htmlFilesUnder(root) {
   return files.sort();
 }
 
-function verifyRenderedIndexability(publishDir, netlifyPath) {
+function verifyRenderedIndexability(
+  publishDir,
+  netlifyPath,
+  robotsPath = path.resolve('static/robots.txt'),
+  host = SITE_HOST,
+) {
   const violations = [];
   const htmlFiles = htmlFilesUnder(publishDir);
   for (const filename of htmlFiles) {
@@ -88,18 +163,47 @@ function verifyRenderedIndexability(publishDir, netlifyPath) {
     violations.push(`X-Robots-Tag at ${netlifyPath}:${directive.line}: ${directive.value}`);
   }
 
+  const sitemapPath = path.join(publishDir, 'sitemap.xml');
+  regularFile(sitemapPath);
+  regularFile(robotsPath);
+  const sitemapXml = fs.readFileSync(sitemapPath, 'utf8');
+  const robotsText = fs.readFileSync(robotsPath, 'utf8');
+  const urls = sitemapUrls(sitemapXml, host);
+  if (!urls.length) {
+    throw new Error(`No ${host} URLs found in ${sitemapPath}`);
+  }
+  const blockedSitemapUrls = sitemapRobotsViolations(sitemapXml, robotsText, host);
+  if (blockedSitemapUrls.length) {
+    throw new Error(
+      'Sitemap URL(s) are blocked by the wildcard robots.txt policy:\n  ' +
+      `${blockedSitemapUrls.join('\n  ')}\n` +
+      'Remove the URL from the sitemap when the block is intentional. ' +
+      'Change the robots crawling policy only when crawling is intended and explicitly approved. ' +
+      'Do not weaken this gate to make the build pass without explicit user approval.',
+    );
+  }
+
   if (violations.length) {
     throw new Error(`Found noindex directive(s):\n  ${violations.join('\n  ')}`);
   }
-  return {htmlFiles: htmlFiles.length, noindexDirectives: 0};
+  return {
+    htmlFiles: htmlFiles.length,
+    noindexDirectives: 0,
+    sitemapUrls: urls.length,
+    blockedSitemapUrls: 0,
+  };
 }
 
 if (require.main === module) {
   try {
     const publishDir = path.resolve(process.argv[2] || 'build');
     const netlifyPath = path.resolve(process.argv[3] || 'netlify.toml');
-    const result = verifyRenderedIndexability(publishDir, netlifyPath);
-    console.log(`Verified zero noindex directives across ${result.htmlFiles} rendered HTML files.`);
+    const robotsPath = path.resolve(process.argv[4] || 'static/robots.txt');
+    const result = verifyRenderedIndexability(publishDir, netlifyPath, robotsPath);
+    console.log(
+      `Verified zero noindex directives across ${result.htmlFiles} rendered HTML files and ` +
+      `zero robots-blocked URLs across ${result.sitemapUrls} sitemap URLs.`,
+    );
   } catch (error) {
     console.error(`Rendered indexability verification failed: ${error.message}`);
     process.exitCode = 1;
@@ -109,5 +213,8 @@ if (require.main === module) {
 module.exports = {
   noindexMetaDirectives,
   noindexResponseHeaders,
+  sitemapRobotsViolations,
   verifyRenderedIndexability,
+  wildcardRobotsAllows,
+  wildcardRobotsRules,
 };

--- a/seo.config.js
+++ b/seo.config.js
@@ -3,6 +3,7 @@ const SITEMAP_EXCLUDED_ROUTES = new Set([
 	'/blog',
 	'/search',
 	'/docs/ask-netdata',
+	'/docs/ask-nedi',
 ]);
 
 function normalizeRoutePath(routePath) {

--- a/src/seo/config.test.js
+++ b/src/seo/config.test.js
@@ -14,6 +14,7 @@ describe('SEO sitemap configuration', () => {
     expect(isSitemapIncludedRoute('/blog/')).toBe(false);
     expect(isSitemapIncludedRoute('/search')).toBe(false);
     expect(isSitemapIncludedRoute('/docs/ask-netdata')).toBe(false);
+    expect(isSitemapIncludedRoute('/docs/ask-nedi')).toBe(false);
   });
 
   it('includes normal documentation and all libnetdata routes', () => {

--- a/src/seo/redirectGraph.test.js
+++ b/src/seo/redirectGraph.test.js
@@ -114,6 +114,9 @@ describe('Netlify redirect graph gate', () => {
     expect(publishedRoutes.has('/docs/ask-nedi')).toBe(true);
     const sitemap = await fs.readFile(path.join(root, 'build/sitemap.xml'), 'utf8');
     expect(sitemap).not.toContain('<loc>https://learn.netdata.cloud/</loc>');
+    expect(sitemap).not.toContain('<loc>https://learn.netdata.cloud/docs/ask-nedi</loc>');
+    const robots = await fs.readFile(path.join(root, 'static/robots.txt'), 'utf8');
+    expect(robots).toMatch(/^Disallow:\s*\/docs\/ask-nedi\/?$/m);
   });
 
   it('does not invent a rendered root route when the build has no root artifact', async () => {

--- a/src/seo/renderedIndexability.test.js
+++ b/src/seo/renderedIndexability.test.js
@@ -6,6 +6,7 @@ import {afterEach, describe, expect, it} from 'vitest';
 import {
   noindexMetaDirectives,
   noindexResponseHeaders,
+  sitemapRobotsViolations,
   verifyRenderedIndexability,
 } from '../../scripts/verify-rendered-indexability';
 
@@ -17,15 +18,21 @@ afterEach(() => {
   }
 });
 
-function fixture(html, netlify = '') {
+function fixture(html, netlify = '', robots = 'User-agent: *\nDisallow:\n') {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'learn-indexability-'));
   roots.push(root);
   const publishDir = path.join(root, 'build');
   fs.mkdirSync(path.join(publishDir, 'docs'), {recursive: true});
   fs.writeFileSync(path.join(publishDir, 'docs', 'index.html'), html);
+  fs.writeFileSync(
+    path.join(publishDir, 'sitemap.xml'),
+    '<urlset><url><loc>https://learn.netdata.cloud/docs</loc></url></urlset>',
+  );
   const netlifyPath = path.join(root, 'netlify.toml');
   fs.writeFileSync(netlifyPath, netlify);
-  return {publishDir, netlifyPath};
+  const robotsPath = path.join(root, 'robots.txt');
+  fs.writeFileSync(robotsPath, robots);
+  return {publishDir, netlifyPath, robotsPath};
 }
 
 describe('rendered indexability verifier', () => {
@@ -35,9 +42,11 @@ describe('rendered indexability verifier', () => {
       '<body><code>X-Robots-Tag: noindex</code></body></html>',
       '[[headers]]\n  for = "/assets/*"\n  [headers.values]\n    Cache-Control = "public"\n',
     );
-    expect(verifyRenderedIndexability(files.publishDir, files.netlifyPath)).toEqual({
+    expect(verifyRenderedIndexability(files.publishDir, files.netlifyPath, files.robotsPath)).toEqual({
       htmlFiles: 1,
       noindexDirectives: 0,
+      sitemapUrls: 1,
+      blockedSitemapUrls: 0,
     });
   });
 
@@ -48,7 +57,7 @@ describe('rendered indexability verifier', () => {
   ])('rejects an actual noindex metadata directive: %s', (meta) => {
     expect(noindexMetaDirectives(`<html><head>${meta}</head></html>`)).toHaveLength(1);
     const files = fixture(`<html><head>${meta}</head></html>`);
-    expect(() => verifyRenderedIndexability(files.publishDir, files.netlifyPath)).toThrow(
+    expect(() => verifyRenderedIndexability(files.publishDir, files.netlifyPath, files.robotsPath)).toThrow(
       /noindex directive/,
     );
   });
@@ -64,7 +73,7 @@ describe('rendered indexability verifier', () => {
       {line: 5, value: 'nofollow, noindex'},
     ]);
     const files = fixture('<html><head><title>Public</title></head></html>', netlify);
-    expect(() => verifyRenderedIndexability(files.publishDir, files.netlifyPath)).toThrow(
+    expect(() => verifyRenderedIndexability(files.publishDir, files.netlifyPath, files.robotsPath)).toThrow(
       /X-Robots-Tag/,
     );
   });
@@ -74,8 +83,39 @@ describe('rendered indexability verifier', () => {
     const outside = path.join(path.dirname(files.publishDir), 'outside.html');
     fs.writeFileSync(outside, '<html></html>');
     fs.symlinkSync(outside, path.join(files.publishDir, 'linked.html'));
-    expect(() => verifyRenderedIndexability(files.publishDir, files.netlifyPath)).toThrow(
+    expect(() => verifyRenderedIndexability(files.publishDir, files.netlifyPath, files.robotsPath)).toThrow(
       /symbolic link/,
     );
+  });
+
+  it('rejects sitemap URLs blocked by the wildcard robots group', () => {
+    const robots = 'User-agent: *\nDisallow: /docs\n';
+    expect(sitemapRobotsViolations(
+      '<urlset><url><loc>https://learn.netdata.cloud/docs/ask-nedi</loc></url></urlset>',
+      robots,
+    )).toEqual(['https://learn.netdata.cloud/docs/ask-nedi']);
+
+    const files = fixture('<html><head><title>Public</title></head></html>', '', robots);
+    expect(() => verifyRenderedIndexability(
+      files.publishDir,
+      files.netlifyPath,
+      files.robotsPath,
+    )).toThrow(/Remove the URL from the sitemap when the block is intentional/);
+  });
+
+  it('honors a more specific Allow rule in the wildcard robots group', () => {
+    const robots = 'User-agent: *\nDisallow: /docs\nAllow: /docs/public\n';
+    expect(sitemapRobotsViolations(
+      '<urlset><url><loc>https://learn.netdata.cloud/docs/public</loc></url></urlset>',
+      robots,
+    )).toEqual([]);
+  });
+
+  it('uses the complete rule-path length for wildcard precedence', () => {
+    const robots = 'User-agent: *\nAllow: /page\nDisallow: /*.htm\n';
+    expect(sitemapRobotsViolations(
+      '<urlset><url><loc>https://learn.netdata.cloud/page.htm</loc></url></urlset>',
+      robots,
+    )).toEqual(['https://learn.netdata.cloud/page.htm']);
   });
 });


### PR DESCRIPTION
## Summary

- exclude /docs/ask-nedi from the generated sitemap
- keep the universal / redirect to Ask Nedi and the existing robots.txt disallow unchanged
- fail the production build when any sitemap URL is blocked by the wildcard robots.txt policy
- give contributors an explicit CI error explaining that an intentionally blocked URL belongs outside the sitemap and that the gate must not be weakened
- update the source-owned SEO acceptance contract with the measured rendered counts

## Why

The sitemap submitted /docs/ask-nedi while robots.txt blocked crawlers from fetching it. This sent contradictory instructions to search engines and could leave the URL indexed without page content.

## Unchanged behavior

- users and bots still receive the same permanent / -> /docs/ask-nedi redirect
- robots.txt is unchanged
- no content, generated documentation, redirect, noindex, Ask Nedi runtime, or IndexNow code changed

## Validation

- 54 Python ingest/recovery tests
- 54 MDX escaping tests
- 27 Vitest files / 394 assertions
- 64 IndexNow assertions
- 4 C8 integration tests
- two byte-identical production builds: 4,157 files, SHA-256 fefdc6d0b9f5cef71b1e1127f32b84f30391673e106e006bb6e1ac79a69b5912
- 1,978 unique sitemap URLs, all with lastmod and none blocked by robots.txt
- 1,984 rendered HTML files with zero noindex directives
- redirect, rendered-link, title, RUM, and C8 gates pass with zero findings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Excludes /docs/ask-nedi from the sitemap and adds a production gate that fails when any sitemap URL is blocked by the wildcard robots.txt policy. Previously the sitemap included /docs/ask-nedi while robots.txt disallowed it; now the sitemap aligns with robots rules to avoid contradictory crawl signals.

- Keeps the permanent / -> /docs/ask-nedi redirect and robots.txt unchanged; only the sitemap changes.
- Extends the `verify-rendered-indexability.js` check to parse the sitemap, evaluate wildcard robots precedence, and emit an explicit CI error when mismatched.
- Updates tests to cover the exclusion and robots precedence; refreshes the source-owned SEO acceptance contract and counts (e.g., sitemap URLs drop by 1).
- Contributor action: when blocking a route in robots.txt intentionally, remove it from the sitemap instead of relaxing the robots policy.

<sup>Written for commit 748129715be1e4df77a821eabe6a0bec7ccdf15b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/learn/pull/2987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **SEO Improvements**
  * Updated sitemap and robots.txt validation to detect blocked or empty sitemap URLs.
  * Added support for wildcard rules, specific allow exceptions, and rule precedence.
  * Excluded the Ask Nedi documentation route from the sitemap and robots.txt access.

* **Bug Fixes**
  * Improved indexability checks to report sitemap URL totals and robots-blocked URLs.

* **Tests**
  * Expanded coverage for sitemap exclusions, robots rules, noindex behavior, and rendered page validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->