### PR TITLE
Scope Nedi CDN assets to the Ask Nedi route

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -230,8 +230,6 @@ module.exports = {
 		],
 	],
 	stylesheets: [
-		// Nedi embed styles
-			'https://nedi.netdata.cloud/ai-agent-ui.css?v=19',
 		{
 			href: '/font/ibm-plex-sans-v8-latin-regular.woff2',
 			rel: 'preload',
@@ -273,15 +271,8 @@ module.exports = {
         defer: true,
         'data-reo-client-id': '8a197d1119ef2d4',
       },
-      // Nedi dependencies (CDN) - async to avoid blocking other scripts
-      { src: 'https://cdn.jsdelivr.net/npm/markdown-it@15.0.0/dist/browser/markdown-it.umd.min.js', async: true },
-      { src: 'https://cdn.jsdelivr.net/npm/mermaid@11.16.1/dist/mermaid.min.js', async: true },
-      { src: 'https://cdn.jsdelivr.net/npm/@viz-js/viz@3.29.0/dist/viz-global.js', async: true },
-      { src: 'https://cdn.jsdelivr.net/npm/turndown@7.2.4/dist/turndown.js', async: true },
-      { src: 'https://cdn.jsdelivr.net/npm/@guyplusplus/turndown-plugin-gfm@1.0.7/dist/turndown-plugin-gfm.js', async: true },
-      // Nedi embed
-      { src: 'https://nedi.netdata.cloud/ai-agent-public.js?v=19', async: true },
-      { src: 'https://nedi.netdata.cloud/ai-agent-ui.js?v=19', async: true },
+      // The Nedi embed, its stylesheet and its CDN dependencies are route-scoped:
+      // src/components/Nedi/assets.js injects them on the Ask Nedi page only.
     ],
     headTags: [
       {

--- a/src/__mocks__/@docusaurus/Head.js
+++ b/src/__mocks__/@docusaurus/Head.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+// The real component renders nothing into the tree; this records the declared tags so
+// tests can assert what would reach the document head.
+export default function Head({ link = [], script = [], children = null }) {
+  return React.createElement(
+    'div',
+    {
+      'data-testid': 'docusaurus-head',
+      'data-link': JSON.stringify(link),
+      'data-script': JSON.stringify(script),
+    },
+    children,
+  );
+}

--- a/src/components/Nedi/assets.js
+++ b/src/components/Nedi/assets.js
@@ -39,6 +39,32 @@ export const NEDI_ASSETS = [
   { type: 'js', src: `${NEDI_ENDPOINT}/ai-agent-ui.js?v=19` },
 ];
 
+// Route that owns the embed. Docusaurus serves it with and without a trailing slash.
+export const NEDI_ROUTE = '/docs/ask-nedi';
+
+export const isNediRoute = (pathname) =>
+  typeof pathname === 'string' && pathname.replace(/\/+$/, '') === NEDI_ROUTE;
+
+// The route a document was rendered for: its entry URL in the browser, or the route
+// being rendered on the server, where there is no entry URL to read.
+export const documentPathname = (routePathname) =>
+  typeof window === 'undefined' ? routePathname : window.location.pathname;
+
+// Shapes for the server-rendered declaration in src/theme/Root.js. react-helmet-async
+// builds its client tags with setAttribute, so a boolean attribute must be declared as
+// an empty string for the client tag to be isEqualNode-equal to the rendered one.
+export const NEDI_HEAD_TAGS = {
+  link: NEDI_ASSETS.filter((asset) => asset.type === 'css').map((asset) => ({
+    rel: 'stylesheet',
+    href: asset.src,
+  })),
+  script: NEDI_ASSETS.filter((asset) => asset.type === 'js').map((asset) =>
+    asset.integrity
+      ? { src: asset.src, async: '', integrity: asset.integrity, crossorigin: 'anonymous' }
+      : { src: asset.src, async: '' },
+  ),
+};
+
 let injected = [];
 let loadFailed = false;
 
@@ -68,6 +94,15 @@ function createAssetElement(asset) {
   return script;
 }
 
+// A tag the server already rendered for this route is loading the asset itself.
+function assetIsDeclared(asset) {
+  const selector =
+    asset.type === 'css'
+      ? `link[rel="stylesheet"][href="${asset.src}"]`
+      : `script[src="${asset.src}"]`;
+  return document.head.querySelector(selector) !== null;
+}
+
 function removeNediAssets() {
   injected.forEach((element) => {
     element.onerror = null;
@@ -77,17 +112,14 @@ function removeNediAssets() {
   loadFailed = false;
 }
 
-export function loadNediAssets() {
-  if (injected.length || nediDependenciesReady()) return;
-
-  // The embed reports this identifier with every conversation it starts.
-  window.AI_AGENT_UI_SOURCE = 'learn';
-
+function injectNediAssets({ force }) {
   const onError = () => {
     loadFailed = true;
   };
 
   NEDI_ASSETS.forEach((asset) => {
+    if (!force && assetIsDeclared(asset)) return;
+
     const element = createAssetElement(asset);
     element.onerror = onError;
     document.head.appendChild(element);
@@ -95,13 +127,27 @@ export function loadNediAssets() {
   });
 }
 
-// Discards a failed injection so the next load starts from a clean head. An already
-// usable set is kept: removing a <script> element does not undo its side effects, so
-// re-requesting it would only cost the stylesheet another round trip.
+// Requests whatever the document is not already loading. On a direct load of the route
+// every asset is declared server-side and nothing is injected; on a client-side entry
+// none are and all are injected. A server-rendered tag that failed is not detected
+// here, because its error fired before this runs; the readiness timeout covers it.
+export function loadNediAssets() {
+  // The embed reads this identifier when it is constructed.
+  window.AI_AGENT_UI_SOURCE = 'learn';
+
+  if (injected.length || nediDependenciesReady()) return;
+
+  injectNediAssets({ force: false });
+}
+
+// Discards a failed attempt and requests every asset again, including any that a
+// server-rendered tag failed to deliver. An already usable set is kept instead:
+// removing a <script> element does not undo its side effects, so re-requesting it
+// would only cost the stylesheet another round trip.
 export function reloadNediAssets() {
   loadFailed = false;
   if (nediDependenciesReady()) return;
 
   removeNediAssets();
-  loadNediAssets();
+  injectNediAssets({ force: true });
 }

--- a/src/components/Nedi/assets.js
+++ b/src/components/Nedi/assets.js
@@ -1,0 +1,102 @@
+import { ensureMarkdownItCompatibility } from './markdownItCompatibility';
+
+export const NEDI_ENDPOINT = 'https://nedi.netdata.cloud';
+
+// The embed and its dependencies are only useful on the Ask Nedi route, so they are
+// injected from this component instead of being declared in the site-wide head.
+//
+// jsDelivr paths are version-pinned and immutable, so they carry Subresource Integrity
+// hashes. The endpoint's own bundles are redeployed in place behind a short cache, so a
+// pinned hash there would reject the asset after the next endpoint release.
+export const NEDI_ASSETS = [
+  { type: 'css', src: `${NEDI_ENDPOINT}/ai-agent-ui.css?v=19` },
+  {
+    type: 'js',
+    src: 'https://cdn.jsdelivr.net/npm/markdown-it@15.0.0/dist/browser/markdown-it.umd.min.js',
+    integrity: 'sha384-RFgiWKVXntFwXKC7cM/vTNo+YCPWtoe5WjzaQWX8NMxIt3CnW1Sjhgt6YPVyrGT5',
+  },
+  {
+    type: 'js',
+    src: 'https://cdn.jsdelivr.net/npm/mermaid@11.16.1/dist/mermaid.min.js',
+    integrity: 'sha384-aBQXj4hK6Jm05i7aQAsUV3bLdSUrHX1BGYfMB0166TtWt/RRaw+h0Eelme9OCOvy',
+  },
+  {
+    type: 'js',
+    src: 'https://cdn.jsdelivr.net/npm/@viz-js/viz@3.29.0/dist/viz-global.js',
+    integrity: 'sha384-39ZxW8vr+xPchaaptsOWpdQjpckcdy40zkLeHLA4Yv3x0el06s2iBnWQ/s/ppFXQ',
+  },
+  {
+    type: 'js',
+    src: 'https://cdn.jsdelivr.net/npm/turndown@7.2.4/dist/turndown.js',
+    integrity: 'sha384-VRHmZZ8b5mH5yknWcg48OJS6RmXZmlgvsqhOXJqY0rwvwirs1M12xd+49c3NpW6a',
+  },
+  {
+    type: 'js',
+    src: 'https://cdn.jsdelivr.net/npm/@guyplusplus/turndown-plugin-gfm@1.0.7/dist/turndown-plugin-gfm.js',
+    integrity: 'sha384-b4AQtiEmaWubq+mFwFnRJCHtHL9HxF2bSrT67eGId8giR2orvUqJFaLQN5NsUP89',
+  },
+  { type: 'js', src: `${NEDI_ENDPOINT}/ai-agent-public.js?v=19` },
+  { type: 'js', src: `${NEDI_ENDPOINT}/ai-agent-ui.js?v=19` },
+];
+
+let injected = [];
+let loadFailed = false;
+
+export const nediDependenciesReady = () =>
+  typeof window !== 'undefined' &&
+  typeof window.AiAgentChatUI !== 'undefined' &&
+  ensureMarkdownItCompatibility(window);
+
+export const nediAssetsFailed = () => loadFailed;
+
+function createAssetElement(asset) {
+  if (asset.type === 'css') {
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = asset.src;
+    return link;
+  }
+
+  const script = document.createElement('script');
+  script.src = asset.src;
+  // Dynamically inserted scripts default to async; the embed expects markdown-it first.
+  script.async = false;
+  if (asset.integrity) {
+    script.setAttribute('integrity', asset.integrity);
+    script.setAttribute('crossorigin', 'anonymous');
+  }
+  return script;
+}
+
+function removeNediAssets() {
+  injected.forEach((element) => {
+    element.onerror = null;
+    element.remove();
+  });
+  injected = [];
+  loadFailed = false;
+}
+
+export function loadNediAssets() {
+  if (injected.length || nediDependenciesReady()) return;
+
+  // The embed reports this identifier with every conversation it starts.
+  window.AI_AGENT_UI_SOURCE = 'learn';
+
+  const onError = () => {
+    loadFailed = true;
+  };
+
+  NEDI_ASSETS.forEach((asset) => {
+    const element = createAssetElement(asset);
+    element.onerror = onError;
+    document.head.appendChild(element);
+    injected.push(element);
+  });
+}
+
+// Discards a failed injection so the next load starts from a clean head.
+export function reloadNediAssets() {
+  removeNediAssets();
+  loadNediAssets();
+}

--- a/src/components/Nedi/assets.js
+++ b/src/components/Nedi/assets.js
@@ -95,8 +95,13 @@ export function loadNediAssets() {
   });
 }
 
-// Discards a failed injection so the next load starts from a clean head.
+// Discards a failed injection so the next load starts from a clean head. An already
+// usable set is kept: removing a <script> element does not undo its side effects, so
+// re-requesting it would only cost the stylesheet another round trip.
 export function reloadNediAssets() {
+  loadFailed = false;
+  if (nediDependenciesReady()) return;
+
   removeNediAssets();
   loadNediAssets();
 }

--- a/src/components/Nedi/assets.test.js
+++ b/src/components/Nedi/assets.test.js
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const freshAssets = async () => {
   vi.resetModules();
@@ -97,7 +97,7 @@ describe('Nedi asset loader', () => {
     loadNediAssets();
 
     expect(injectedElements()).toHaveLength(0);
-    expect(window.AI_AGENT_UI_SOURCE).toBeUndefined();
+    expect(window.AI_AGENT_UI_SOURCE).toBe('learn');
   });
 
   it('reports dependencies as unusable until both the embed and markdown-it exist', async () => {
@@ -138,6 +138,52 @@ describe('Nedi asset loader', () => {
     expect(injectedElements()).toHaveLength(NEDI_ASSETS.length);
   });
 
+  it('adopts a declared asset instead of requesting it twice', async () => {
+    const { NEDI_ASSETS, loadNediAssets } = await freshAssets();
+    const declared = document.createElement('script');
+    declared.src = NEDI_ASSETS[1].src;
+    document.head.appendChild(declared);
+
+    loadNediAssets();
+
+    const scripts = injectedScripts();
+    expect(scripts.filter((script) => script.src === NEDI_ASSETS[1].src)).toEqual([declared]);
+    expect(injectedElements()).toHaveLength(NEDI_ASSETS.length);
+  });
+
+  it('injects nothing when every asset is already declared', async () => {
+    const { NEDI_ASSETS, loadNediAssets } = await freshAssets();
+    NEDI_ASSETS.forEach((asset) => {
+      const element = document.createElement(asset.type === 'css' ? 'link' : 'script');
+      if (asset.type === 'css') {
+        element.rel = 'stylesheet';
+        element.href = asset.src;
+      } else {
+        element.src = asset.src;
+      }
+      document.head.appendChild(element);
+    });
+
+    loadNediAssets();
+
+    expect(injectedElements()).toHaveLength(NEDI_ASSETS.length);
+    expect(window.AI_AGENT_UI_SOURCE).toBe('learn');
+  });
+
+  it('requests every asset again on reload, including declared ones', async () => {
+    const { NEDI_ASSETS, loadNediAssets, reloadNediAssets } = await freshAssets();
+    const declared = document.createElement('script');
+    declared.src = NEDI_ASSETS[1].src;
+    document.head.appendChild(declared);
+    loadNediAssets();
+
+    reloadNediAssets();
+
+    // The declared tag is left alone; a retry re-requests the asset it failed to deliver.
+    expect(declared.isConnected).toBe(true);
+    expect(injectedScripts().filter((script) => script.src === NEDI_ASSETS[1].src)).toHaveLength(2);
+  });
+
   it('replaces a failed injection with fresh elements on reload', async () => {
     const { NEDI_ASSETS, loadNediAssets, reloadNediAssets, nediAssetsFailed } =
       await freshAssets();
@@ -153,5 +199,45 @@ describe('Nedi asset loader', () => {
     expect(second).toHaveLength(NEDI_ASSETS.length);
     expect(second.some((element) => first.includes(element))).toBe(false);
     expect(first.every((element) => element.isConnected === false)).toBe(true);
+  });
+});
+
+describe('Nedi route matching', () => {
+  it('matches the route with and without a trailing slash', async () => {
+    const { NEDI_ROUTE, isNediRoute } = await freshAssets();
+
+    expect(isNediRoute(NEDI_ROUTE)).toBe(true);
+    expect(isNediRoute(`${NEDI_ROUTE}/`)).toBe(true);
+  });
+
+  it('does not match another route or a missing pathname', async () => {
+    const { isNediRoute } = await freshAssets();
+
+    expect(isNediRoute('/docs/netdata-agent')).toBe(false);
+    expect(isNediRoute('/docs/ask-nedi/extra')).toBe(false);
+    expect(isNediRoute('/')).toBe(false);
+    expect(isNediRoute(null)).toBe(false);
+  });
+});
+
+describe('Nedi document pathname', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('reads the entry URL in the browser', async () => {
+    const { documentPathname } = await freshAssets();
+    window.history.replaceState({}, '', '/docs/ask-nedi');
+
+    expect(documentPathname('/docs/netdata-agent')).toBe('/docs/ask-nedi');
+
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('falls back to the rendered route on the server', async () => {
+    const { documentPathname } = await freshAssets();
+    vi.stubGlobal('window', undefined);
+
+    expect(documentPathname('/docs/ask-nedi')).toBe('/docs/ask-nedi');
   });
 });

--- a/src/components/Nedi/assets.test.js
+++ b/src/components/Nedi/assets.test.js
@@ -122,6 +122,22 @@ describe('Nedi asset loader', () => {
     expect(nediAssetsFailed()).toBe(true);
   });
 
+  it('keeps an already usable set on reload instead of re-requesting it', async () => {
+    const { NEDI_ASSETS, loadNediAssets, reloadNediAssets, nediAssetsFailed } =
+      await freshAssets();
+
+    loadNediAssets();
+    const first = injectedElements();
+    stubEmbed();
+    stubMarkdownIt();
+
+    reloadNediAssets();
+
+    expect(nediAssetsFailed()).toBe(false);
+    expect(injectedElements()).toEqual(first);
+    expect(injectedElements()).toHaveLength(NEDI_ASSETS.length);
+  });
+
   it('replaces a failed injection with fresh elements on reload', async () => {
     const { NEDI_ASSETS, loadNediAssets, reloadNediAssets, nediAssetsFailed } =
       await freshAssets();

--- a/src/components/Nedi/assets.test.js
+++ b/src/components/Nedi/assets.test.js
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const freshAssets = async () => {
+  vi.resetModules();
+  return import('./assets');
+};
+
+const injectedElements = () => [...document.head.querySelectorAll('link, script')];
+const injectedScripts = () => [...document.head.querySelectorAll('script')];
+
+const stubMarkdownIt = () => {
+  const markdownIt = () => ({ linkify: { set: () => {} } });
+  window.markdownit = markdownIt;
+};
+
+const stubEmbed = () => {
+  window.AiAgentChatUI = function AiAgentChatUI() {};
+};
+
+describe('Nedi asset loader', () => {
+  beforeEach(() => {
+    injectedElements().forEach((element) => element.remove());
+    delete window.AiAgentChatUI;
+    delete window.markdownit;
+    delete window.AI_AGENT_UI_SOURCE;
+  });
+
+  it('injects the stylesheet first and then every script in declaration order', async () => {
+    const { NEDI_ASSETS, loadNediAssets } = await freshAssets();
+
+    loadNediAssets();
+
+    expect(injectedElements().map((element) => element.tagName)).toEqual([
+      'LINK',
+      ...NEDI_ASSETS.slice(1).map(() => 'SCRIPT'),
+    ]);
+
+    const [link] = injectedElements();
+    expect(link.rel).toBe('stylesheet');
+    expect(link.getAttribute('href')).toBe(NEDI_ASSETS[0].src);
+    expect(injectedScripts().map((script) => script.getAttribute('src'))).toEqual(
+      NEDI_ASSETS.filter((asset) => asset.type === 'js').map((asset) => asset.src),
+    );
+  });
+
+  it('keeps script execution ordered instead of the dynamic-insertion default', async () => {
+    const { loadNediAssets } = await freshAssets();
+
+    loadNediAssets();
+
+    expect(injectedScripts().every((script) => script.async === false)).toBe(true);
+  });
+
+  it('pins integrity only for the version-locked CDN dependencies', async () => {
+    const { NEDI_ASSETS, loadNediAssets } = await freshAssets();
+
+    loadNediAssets();
+
+    const scripts = injectedScripts();
+    NEDI_ASSETS.filter((asset) => asset.type === 'js').forEach((asset, index) => {
+      const script = scripts[index];
+      if (asset.src.startsWith('https://cdn.jsdelivr.net/')) {
+        expect(asset.integrity).toMatch(/^sha384-/);
+        expect(script.getAttribute('integrity')).toBe(asset.integrity);
+        expect(script.getAttribute('crossorigin')).toBe('anonymous');
+      } else {
+        expect(asset.integrity).toBeUndefined();
+        expect(script.hasAttribute('integrity')).toBe(false);
+        expect(script.hasAttribute('crossorigin')).toBe(false);
+      }
+    });
+  });
+
+  it('identifies the embed source before the embed script runs', async () => {
+    const { loadNediAssets } = await freshAssets();
+
+    loadNediAssets();
+
+    expect(window.AI_AGENT_UI_SOURCE).toBe('learn');
+  });
+
+  it('injects at most one copy of each asset', async () => {
+    const { NEDI_ASSETS, loadNediAssets } = await freshAssets();
+
+    loadNediAssets();
+    loadNediAssets();
+
+    expect(injectedElements()).toHaveLength(NEDI_ASSETS.length);
+  });
+
+  it('skips injection when the dependencies are already usable', async () => {
+    const { loadNediAssets, nediDependenciesReady } = await freshAssets();
+    stubEmbed();
+    stubMarkdownIt();
+
+    expect(nediDependenciesReady()).toBe(true);
+    loadNediAssets();
+
+    expect(injectedElements()).toHaveLength(0);
+    expect(window.AI_AGENT_UI_SOURCE).toBeUndefined();
+  });
+
+  it('reports dependencies as unusable until both the embed and markdown-it exist', async () => {
+    const { nediDependenciesReady } = await freshAssets();
+
+    expect(nediDependenciesReady()).toBe(false);
+
+    stubEmbed();
+    expect(nediDependenciesReady()).toBe(false);
+
+    stubMarkdownIt();
+    expect(nediDependenciesReady()).toBe(true);
+  });
+
+  it('records a failure when any asset fails to load', async () => {
+    const { loadNediAssets, nediAssetsFailed } = await freshAssets();
+
+    loadNediAssets();
+    expect(nediAssetsFailed()).toBe(false);
+
+    injectedScripts()[0].dispatchEvent(new Event('error'));
+    expect(nediAssetsFailed()).toBe(true);
+  });
+
+  it('replaces a failed injection with fresh elements on reload', async () => {
+    const { NEDI_ASSETS, loadNediAssets, reloadNediAssets, nediAssetsFailed } =
+      await freshAssets();
+
+    loadNediAssets();
+    const first = injectedElements();
+    first[0].dispatchEvent(new Event('error'));
+
+    reloadNediAssets();
+    const second = injectedElements();
+
+    expect(nediAssetsFailed()).toBe(false);
+    expect(second).toHaveLength(NEDI_ASSETS.length);
+    expect(second.some((element) => first.includes(element))).toBe(false);
+    expect(first.every((element) => element.isConnected === false)).toBe(true);
+  });
+});

--- a/src/components/Nedi/index.js
+++ b/src/components/Nedi/index.js
@@ -1,11 +1,18 @@
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useState, useCallback } from 'react';
 import { useColorMode } from '@docusaurus/theme-common';
 
-import { ensureMarkdownItCompatibility } from './markdownItCompatibility';
+import {
+  NEDI_ENDPOINT,
+  loadNediAssets,
+  reloadNediAssets,
+  nediAssetsFailed,
+  nediDependenciesReady,
+} from './assets';
 
-const NEDI_ENDPOINT = 'https://nedi.netdata.cloud';
 const PERSISTENT_ID = 'nedi-persistent';
 const SCROLL_KEY = 'nedi-scroll-y';
+const READY_POLL_INTERVAL = 150;
+const READY_TIMEOUT = 15000;
 
 // Match Docusaurus theme colors for seamless integration
 const CSS_VARIABLES = {
@@ -34,10 +41,7 @@ const CSS_VARIABLES = {
   },
 };
 
-// Set source identifier for Nedi analytics
-if (typeof window !== 'undefined') {
-  window.AI_AGENT_UI_SOURCE = 'learn';
-}
+const STATUS_STYLE = { textAlign: 'center', padding: '40px' };
 
 // Persistent container + instance, survives React unmounts
 function getOrCreateNedi(theme) {
@@ -73,72 +77,100 @@ function getOrCreateNedi(theme) {
 export default function Nedi() {
   const mountRef = useRef(null);
   const { colorMode } = useColorMode();
+  const colorModeRef = useRef(colorMode);
+  colorModeRef.current = colorMode;
 
+  const [ready, setReady] = useState(false);
+  const [failed, setFailed] = useState(false);
+  const [attempt, setAttempt] = useState(0);
+
+  const retry = useCallback(() => {
+    reloadNediAssets();
+    setFailed(false);
+    setAttempt((count) => count + 1);
+  }, []);
+
+  // Inject the embed and its dependencies, then wait for them to become usable.
   useEffect(() => {
-    if (!mountRef.current) return;
+    if (ready || failed) return undefined;
 
-    let cleanups = [];
-
-    const boot = () => {
-      if (!mountRef.current) return;
-      if (typeof window.AiAgentChatUI === 'undefined') return false;
-      if (!ensureMarkdownItCompatibility(window)) return false;
-
-      const nediEl = getOrCreateNedi(colorMode);
-
-      // Move persistent container into the mount point
-      mountRef.current.appendChild(nediEl);
-      nediEl.style.display = '';
-
-      // Ensure containers fill viewport so sticky footer stays at bottom even when empty.
-      // Uses document-relative position (rect.top + scrollY) so the value stays
-      // correct even when a resize fires while the user is scrolled down.
-      const setMinHeight = () => {
-        const top = mountRef.current.getBoundingClientRect().top + window.scrollY;
-        const vh = `calc(100vh - ${top}px)`;
-        mountRef.current.style.minHeight = vh;
-        nediEl.style.minHeight = vh;
-        const wrapper = nediEl.querySelector('.ai-agent-wrapper');
-        if (wrapper) wrapper.style.minHeight = vh;
-      };
-      requestAnimationFrame(setMinHeight);
-      // SPA back-navigation: layout may need extra time to settle
-      const settleTimer = setTimeout(setMinHeight, 150);
-      window.addEventListener('resize', setMinHeight);
-
-      // Save scroll position continuously while on this page
-      const onScroll = () => sessionStorage.setItem(SCROLL_KEY, String(window.scrollY));
-      window.addEventListener('scroll', onScroll, { passive: true });
-
-      // Restore scroll position after DOM settles
-      const savedScroll = sessionStorage.getItem(SCROLL_KEY);
-      if (savedScroll) {
-        setTimeout(() => window.scrollTo(0, parseInt(savedScroll, 10)), 50);
-      }
-
-      // Focus the chat input after DOM settles
-      requestAnimationFrame(() => {
-        const input = nediEl.querySelector('.ai-agent-input');
-        if (input) input.focus();
-      });
-
-      cleanups = [
-        () => clearTimeout(settleTimer),
-        () => window.removeEventListener('scroll', onScroll),
-        () => window.removeEventListener('resize', setMinHeight),
-        () => { nediEl.style.display = 'none'; document.body.appendChild(nediEl); },
-      ];
-      return true;
-    };
-
-    // Try immediately; poll if async script hasn't loaded yet
-    if (!boot()) {
-      const poll = setInterval(() => { if (boot()) clearInterval(poll); }, 150);
-      cleanups.push(() => clearInterval(poll));
+    loadNediAssets();
+    if (nediDependenciesReady()) {
+      setReady(true);
+      return undefined;
     }
 
-    return () => cleanups.forEach(fn => fn());
-  }, []);
+    const poll = setInterval(() => {
+      if (nediDependenciesReady()) setReady(true);
+      else if (nediAssetsFailed()) setFailed(true);
+    }, READY_POLL_INTERVAL);
+
+    const timeout = setTimeout(() => setFailed(true), READY_TIMEOUT);
+
+    return () => {
+      clearInterval(poll);
+      clearTimeout(timeout);
+    };
+  }, [ready, failed, attempt]);
+
+  useEffect(() => {
+    if (!ready || !mountRef.current) return undefined;
+
+    const mount = mountRef.current;
+    let nediEl;
+    try {
+      nediEl = getOrCreateNedi(colorModeRef.current);
+    } catch {
+      setReady(false);
+      setFailed(true);
+      return undefined;
+    }
+
+    // Move persistent container into the mount point
+    mount.appendChild(nediEl);
+    nediEl.style.display = '';
+
+    // Ensure containers fill viewport so sticky footer stays at bottom even when empty.
+    // Uses document-relative position (rect.top + scrollY) so the value stays
+    // correct even when a resize fires while the user is scrolled down.
+    const setMinHeight = () => {
+      const top = mount.getBoundingClientRect().top + window.scrollY;
+      const vh = `calc(100vh - ${top}px)`;
+      mount.style.minHeight = vh;
+      nediEl.style.minHeight = vh;
+      const wrapper = nediEl.querySelector('.ai-agent-wrapper');
+      if (wrapper) wrapper.style.minHeight = vh;
+    };
+    requestAnimationFrame(setMinHeight);
+    // SPA back-navigation: layout may need extra time to settle
+    const settleTimer = setTimeout(setMinHeight, 150);
+    window.addEventListener('resize', setMinHeight);
+
+    // Save scroll position continuously while on this page
+    const onScroll = () => sessionStorage.setItem(SCROLL_KEY, String(window.scrollY));
+    window.addEventListener('scroll', onScroll, { passive: true });
+
+    // Restore scroll position after DOM settles
+    const savedScroll = sessionStorage.getItem(SCROLL_KEY);
+    const scrollTimer = savedScroll
+      ? setTimeout(() => window.scrollTo(0, parseInt(savedScroll, 10)), 50)
+      : undefined;
+
+    // Focus the chat input after DOM settles
+    requestAnimationFrame(() => {
+      const input = nediEl.querySelector('.ai-agent-input');
+      if (input) input.focus();
+    });
+
+    return () => {
+      clearTimeout(settleTimer);
+      clearTimeout(scrollTimer);
+      window.removeEventListener('scroll', onScroll);
+      window.removeEventListener('resize', setMinHeight);
+      nediEl.style.display = 'none';
+      document.body.appendChild(nediEl);
+    };
+  }, [ready]);
 
   // Sync Docusaurus theme changes to Nedi
   useEffect(() => {
@@ -148,5 +180,23 @@ export default function Nedi() {
     }
   }, [colorMode]);
 
-  return <div ref={mountRef} />;
+  return (
+    <>
+      <div ref={mountRef} />
+      {!ready && (
+        <div style={STATUS_STYLE} role="status" aria-live="polite">
+          {failed ? (
+            <>
+              <p>Ask Nedi could not be loaded.</p>
+              <button type="button" onClick={retry}>
+                Retry
+              </button>
+            </>
+          ) : (
+            <p>Loading Ask Nedi...</p>
+          )}
+        </div>
+      )}
+    </>
+  );
 }

--- a/src/components/Nedi/index.js
+++ b/src/components/Nedi/index.js
@@ -55,22 +55,28 @@ function getOrCreateNedi(theme) {
 
   window.AiAgentChatConfig = { endpoint: NEDI_ENDPOINT };
 
-  const instance = new window.AiAgentChatUI(container, {
-    mode: 'div',
-    agentId: 'support-public',
-    theme,
-    showThemeToggle: false,
-    stickyInput: true,
-    cssVariables: CSS_VARIABLES,
-    urlParams: ['q', 'question'],
-    onEvent: (event) => {
-      if (event.type === 'user-message' && window.posthog) {
-        window.posthog.capture('nedi_question', { question: event.content });
-      }
-    },
-  });
+  try {
+    container.__nediInstance = new window.AiAgentChatUI(container, {
+      mode: 'div',
+      agentId: 'support-public',
+      theme,
+      showThemeToggle: false,
+      stickyInput: true,
+      cssVariables: CSS_VARIABLES,
+      urlParams: ['q', 'question'],
+      onEvent: (event) => {
+        if (event.type === 'user-message' && window.posthog) {
+          window.posthog.capture('nedi_question', { question: event.content });
+        }
+      },
+    });
+  } catch (error) {
+    // The container is attached before the embed starts, so a failed start must not
+    // leave an instance-less container behind: the next attempt would adopt it.
+    container.remove();
+    throw error;
+  }
 
-  container.__nediInstance = instance;
   return container;
 }
 

--- a/src/components/Nedi/index.test.js
+++ b/src/components/Nedi/index.test.js
@@ -247,4 +247,28 @@ describe('Nedi component', () => {
 
     expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
   });
+
+  it('discards the container of an embed that failed to start', () => {
+    let attempts = 0;
+    window.AiAgentChatUI = function AiAgentChatUI(container, options) {
+      attempts += 1;
+      if (attempts === 1) throw new Error('embed unavailable');
+      embedOptions = options;
+      container.innerHTML =
+        '<div class="ai-agent-wrapper"><input class="ai-agent-input" /></div>';
+      this.setTheme = setTheme;
+      container.__nediInstance = this;
+    };
+    nediDependenciesReady.mockReturnValue(true);
+    render(<Nedi />);
+
+    expect(document.getElementById(PERSISTENT_ID)).toBeNull();
+
+    act(() => screen.getByRole('button', { name: 'Retry' }).click());
+    tick(150);
+
+    expect(attempts).toBe(2);
+    expect(document.getElementById(PERSISTENT_ID).__nediInstance).toBeDefined();
+    expect(screen.queryByRole('status')).toBeNull();
+  });
 });

--- a/src/components/Nedi/index.test.js
+++ b/src/components/Nedi/index.test.js
@@ -1,0 +1,250 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, render, screen } from '@testing-library/react';
+
+import { __setMockColorMode } from '@docusaurus/theme-common';
+import {
+  loadNediAssets,
+  reloadNediAssets,
+  nediAssetsFailed,
+  nediDependenciesReady,
+} from './assets';
+import Nedi from './index';
+
+vi.mock('./assets', () => ({
+  NEDI_ENDPOINT: 'https://nedi.netdata.cloud',
+  loadNediAssets: vi.fn(),
+  reloadNediAssets: vi.fn(),
+  nediAssetsFailed: vi.fn(() => false),
+  nediDependenciesReady: vi.fn(() => false),
+}));
+
+const PERSISTENT_ID = 'nedi-persistent';
+const READY_TIMEOUT = 15000;
+
+let embedOptions;
+let setTheme;
+
+function installEmbed() {
+  window.AiAgentChatUI = function AiAgentChatUI(container, options) {
+    embedOptions = options;
+    container.innerHTML =
+      '<div class="ai-agent-wrapper"><input class="ai-agent-input" /></div>';
+    this.setTheme = setTheme;
+    container.__nediInstance = this;
+  };
+}
+
+// Advances past one readiness poll interval and flushes the resulting render.
+const tick = (ms) => act(() => vi.advanceTimersByTime(ms));
+
+describe('Nedi component', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    embedOptions = undefined;
+    setTheme = vi.fn();
+    nediDependenciesReady.mockReturnValue(false);
+    nediAssetsFailed.mockReturnValue(false);
+    sessionStorage.clear();
+    __setMockColorMode('light');
+  });
+
+  afterEach(() => {
+    // Unmount first: the component parks the embed on document.body on cleanup.
+    cleanup();
+    document.getElementById(PERSISTENT_ID)?.remove();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+    delete window.AiAgentChatUI;
+    delete window.AiAgentChatConfig;
+    delete window.posthog;
+  });
+
+  it('requests the assets and reports progress while they load', () => {
+    render(<Nedi />);
+
+    expect(loadNediAssets).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('status')).toHaveTextContent('Loading Ask Nedi...');
+  });
+
+  it('mounts the embed as soon as the dependencies resolve', () => {
+    installEmbed();
+    const { container } = render(<Nedi />);
+
+    nediDependenciesReady.mockReturnValue(true);
+    tick(150);
+
+    const mounted = container.querySelector(`#${PERSISTENT_ID}`);
+    expect(mounted).not.toBeNull();
+    expect(screen.queryByRole('status')).toBeNull();
+    expect(window.AiAgentChatConfig).toEqual({ endpoint: 'https://nedi.netdata.cloud' });
+    expect(embedOptions).toMatchObject({ mode: 'div', agentId: 'support-public', theme: 'light' });
+  });
+
+  it('mounts without polling when the dependencies are already present', () => {
+    installEmbed();
+    nediDependenciesReady.mockReturnValue(true);
+
+    const { container } = render(<Nedi />);
+
+    expect(container.querySelector(`#${PERSISTENT_ID}`)).not.toBeNull();
+  });
+
+  it('sizes the mount and the embed to the remaining viewport', () => {
+    installEmbed();
+    nediDependenciesReady.mockReturnValue(true);
+    const { container } = render(<Nedi />);
+
+    tick(150);
+
+    const mount = container.firstChild;
+    const mounted = document.getElementById(PERSISTENT_ID);
+    expect(mount.style.minHeight).toBe('calc(100vh - 0px)');
+    expect(mounted.style.minHeight).toBe('calc(100vh - 0px)');
+    expect(mounted.querySelector('.ai-agent-wrapper').style.minHeight).toBe('calc(100vh - 0px)');
+    expect(document.activeElement).toBe(mounted.querySelector('.ai-agent-input'));
+  });
+
+  it('tolerates an embed that has not rendered its chat surface yet', () => {
+    window.AiAgentChatUI = function AiAgentChatUI() {};
+    nediDependenciesReady.mockReturnValue(true);
+    render(<Nedi />);
+
+    tick(150);
+
+    const mounted = document.getElementById(PERSISTENT_ID);
+    expect(mounted.style.minHeight).toBe('calc(100vh - 0px)');
+    expect(mounted.querySelector('.ai-agent-input')).toBeNull();
+  });
+
+  it('restores the scroll position recorded on the previous visit', () => {
+    installEmbed();
+    sessionStorage.setItem('nedi-scroll-y', '120');
+    nediDependenciesReady.mockReturnValue(true);
+    render(<Nedi />);
+
+    tick(150);
+
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 120);
+  });
+
+  it('records the scroll position while the page is open', () => {
+    installEmbed();
+    nediDependenciesReady.mockReturnValue(true);
+    render(<Nedi />);
+    tick(150);
+
+    window.scrollY = 42;
+    act(() => window.dispatchEvent(new Event('scroll')));
+
+    expect(sessionStorage.getItem('nedi-scroll-y')).toBe('42');
+  });
+
+  it('parks the embed outside the page on unmount so it survives navigation', () => {
+    installEmbed();
+    nediDependenciesReady.mockReturnValue(true);
+    const { unmount } = render(<Nedi />);
+    tick(150);
+
+    unmount();
+
+    const parked = document.getElementById(PERSISTENT_ID);
+    expect(parked.parentElement).toBe(document.body);
+    expect(parked.style.display).toBe('none');
+  });
+
+  it('reuses the embed instance across remounts', () => {
+    installEmbed();
+    nediDependenciesReady.mockReturnValue(true);
+    const first = render(<Nedi />);
+    tick(150);
+    const instance = document.getElementById(PERSISTENT_ID).__nediInstance;
+    first.unmount();
+
+    const second = render(<Nedi />);
+    tick(150);
+
+    expect(second.container.querySelector(`#${PERSISTENT_ID}`).__nediInstance).toBe(instance);
+  });
+
+  it('forwards a question to the analytics client when one is available', () => {
+    installEmbed();
+    nediDependenciesReady.mockReturnValue(true);
+    window.posthog = { capture: vi.fn() };
+    render(<Nedi />);
+    tick(150);
+
+    embedOptions.onEvent({ type: 'user-message', content: 'why is my disk full' });
+    embedOptions.onEvent({ type: 'other', content: 'ignored' });
+
+    expect(window.posthog.capture).toHaveBeenCalledTimes(1);
+    expect(window.posthog.capture).toHaveBeenCalledWith('nedi_question', {
+      question: 'why is my disk full',
+    });
+  });
+
+  it('drops a question when no analytics client is loaded', () => {
+    installEmbed();
+    nediDependenciesReady.mockReturnValue(true);
+    render(<Nedi />);
+    tick(150);
+
+    expect(() => embedOptions.onEvent({ type: 'user-message', content: 'q' })).not.toThrow();
+  });
+
+  it('follows the Docusaurus color mode', () => {
+    installEmbed();
+    nediDependenciesReady.mockReturnValue(true);
+    const { rerender } = render(<Nedi />);
+    tick(150);
+
+    __setMockColorMode('dark');
+    rerender(<Nedi />);
+
+    expect(setTheme).toHaveBeenCalledWith('dark');
+  });
+
+  it('offers a retry when an asset fails to load', () => {
+    render(<Nedi />);
+
+    nediAssetsFailed.mockReturnValue(true);
+    tick(150);
+
+    expect(screen.getByRole('status')).toHaveTextContent('Ask Nedi could not be loaded.');
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+  });
+
+  it('offers a retry when the dependencies never become usable', () => {
+    render(<Nedi />);
+
+    tick(READY_TIMEOUT);
+
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+  });
+
+  it('re-injects the assets and resumes waiting when retried', () => {
+    render(<Nedi />);
+    tick(READY_TIMEOUT);
+
+    act(() => screen.getByRole('button', { name: 'Retry' }).click());
+
+    expect(reloadNediAssets).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('status')).toHaveTextContent('Loading Ask Nedi...');
+
+    installEmbed();
+    nediDependenciesReady.mockReturnValue(true);
+    tick(150);
+
+    expect(document.getElementById(PERSISTENT_ID)).not.toBeNull();
+  });
+
+  it('offers a retry when the embed refuses to start', () => {
+    window.AiAgentChatUI = function AiAgentChatUI() {
+      throw new Error('embed unavailable');
+    };
+    nediDependenciesReady.mockReturnValue(true);
+
+    render(<Nedi />);
+
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+  });
+});

--- a/src/theme/Root/index.js
+++ b/src/theme/Root/index.js
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import Head from '@docusaurus/Head';
+import { useLocation } from '@docusaurus/router';
+
+import { NEDI_HEAD_TAGS, documentPathname, isNediRoute } from '@site/src/components/Nedi/assets';
+
+// The Ask Nedi route is the only page that uses the embed, so its stylesheet and
+// scripts are declared here rather than in the site-wide head. Rendering them on the
+// server keeps a direct load requesting them from <head>, before hydration.
+//
+// The same tags are declared on the client for a document that was server-rendered for
+// this route. react-helmet-async keeps an existing tag only when the one it builds is
+// isEqualNode-equal to it, and removes every unmatched tag it owns, so a client that
+// declared nothing would drop the stylesheet and re-execute every script at hydration.
+// The declared attribute values are what setAttribute produces, and the HTML minifier
+// preserves empty attribute values, so the two tags match.
+//
+// A client-side entry into the route has no server-rendered tags, and none are declared
+// here because this document was rendered for a different route. The runtime loader in
+// src/components/Nedi/assets.js injects them in that case.
+export default function Root({ children }) {
+  const { pathname } = useLocation();
+  // Root is mounted once per document, so this stays the pathname the document was
+  // rendered for even after client-side navigation.
+  const [renderedPathname] = useState(() => documentPathname(pathname));
+
+  return (
+    <>
+      {isNediRoute(renderedPathname) && (
+        <Head link={NEDI_HEAD_TAGS.link} script={NEDI_HEAD_TAGS.script} />
+      )}
+      {children}
+    </>
+  );
+}

--- a/src/theme/Root/index.test.js
+++ b/src/theme/Root/index.test.js
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { __setMockPathname, __resetMockLocation } from '@docusaurus/router';
+import { NEDI_ASSETS } from '@site/src/components/Nedi/assets';
+import Root from './index';
+
+const declared = () => {
+  const head = screen.queryByTestId('docusaurus-head');
+  if (!head) return null;
+  return {
+    link: JSON.parse(head.getAttribute('data-link')),
+    script: JSON.parse(head.getAttribute('data-script')),
+  };
+};
+
+const renderAt = (pathname) => {
+  window.history.replaceState({}, '', pathname);
+  __setMockPathname(pathname);
+  return render(
+    <Root>
+      <p>page</p>
+    </Root>,
+  );
+};
+
+describe('Root', () => {
+  afterEach(() => {
+    __resetMockLocation();
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('renders the page on every route', () => {
+    renderAt('/docs/netdata-agent');
+
+    expect(screen.getByText('page')).toBeInTheDocument();
+  });
+
+  it('declares no embed assets on other routes', () => {
+    renderAt('/docs/netdata-agent');
+
+    expect(declared()).toBeNull();
+  });
+
+  it('declares the embed assets on the Ask Nedi route', () => {
+    renderAt('/docs/ask-nedi');
+
+    const tags = declared();
+    expect(tags.link).toEqual([
+      { rel: 'stylesheet', href: NEDI_ASSETS[0].src },
+    ]);
+    expect(tags.script.map((tag) => tag.src)).toEqual(
+      NEDI_ASSETS.filter((asset) => asset.type === 'js').map((asset) => asset.src),
+    );
+  });
+
+  it('declares the embed assets on the trailing-slash form of the route', () => {
+    renderAt('/docs/ask-nedi/');
+
+    expect(declared()).not.toBeNull();
+  });
+
+  it('declares scripts as async with integrity only where the asset pins one', () => {
+    renderAt('/docs/ask-nedi');
+
+    declared().script.forEach((tag, index) => {
+      const asset = NEDI_ASSETS.filter((entry) => entry.type === 'js')[index];
+      // An empty string is what setAttribute produces on the client, so the tag the
+      // client builds stays isEqualNode-equal to the server-rendered one.
+      expect(tag.async).toBe('');
+      if (asset.integrity) {
+        expect(tag).toMatchObject({ integrity: asset.integrity, crossorigin: 'anonymous' });
+      } else {
+        expect(tag.integrity).toBeUndefined();
+        expect(tag.crossorigin).toBeUndefined();
+      }
+    });
+  });
+
+  it('keeps declaring the assets after navigating away from the route', () => {
+    const { rerender } = renderAt('/docs/ask-nedi');
+
+    __setMockPathname('/docs/netdata-agent');
+    rerender(
+      <Root>
+        <p>page</p>
+      </Root>,
+    );
+
+    expect(declared()).not.toBeNull();
+  });
+
+  it('declares nothing when entering the route through client-side navigation', () => {
+    const { rerender } = renderAt('/docs/netdata-agent');
+
+    __setMockPathname('/docs/ask-nedi');
+    rerender(
+      <Root>
+        <p>page</p>
+      </Root>,
+    );
+
+    expect(declared()).toBeNull();
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -85,6 +85,7 @@ export default defineConfig({
       { find: '@site', replacement: path.resolve(__dirname, './') },
 
       // Mock Docusaurus core modules
+      { find: '@docusaurus/Head', replacement: path.resolve(__dirname, './src/__mocks__/@docusaurus/Head.js') },
       { find: '@docusaurus/Link', replacement: path.resolve(__dirname, './src/__mocks__/@docusaurus/Link.js') },
       { find: '@docusaurus/router', replacement: path.resolve(__dirname, './src/__mocks__/@docusaurus/router.js') },
       { find: '@docusaurus/theme-common/Details', replacement: path.resolve(__dirname, './src/__mocks__/@docusaurus/theme-common/Details.js') },


### PR DESCRIPTION
## What changed

The Nedi stylesheet and its seven script dependencies moved out of the site-wide
`stylesheets`/`scripts` arrays in `docusaurus.config.js` and into an imperative loader,
`src/components/Nedi/assets.js`, that runs when the Ask Nedi component mounts.

`src/components/Nedi/index.js` is imported only by `docs/ask-nedi.mdx`, so the loader is in that
route's chunk and no other page requests these assets.

## Why

Every page on learn.netdata.cloud downloaded the full Nedi dependency set, even though only
`/docs/ask-nedi` can use it. The stylesheet is a render-blocking cross-origin `<link>` in `<head>`
on every page.

Measured with `curl` against the production URLs on 2026-08-19 (`Accept-Encoding: br` for
transfer, `Accept-Encoding: identity` for uncompressed):

| Asset | Transfer (br) | Uncompressed |
|---|---:|---:|
| `markdown-it@15.0.0` (jsDelivr) | 47,445 | 114,128 |
| `mermaid@11.16.1` (jsDelivr) | 929,386 | 3,566,058 |
| `@viz-js/viz@3.29.0` (jsDelivr) | 480,821 | 1,326,330 |
| `turndown@7.2.4` (jsDelivr) | 7,657 | 26,659 |
| `@guyplusplus/turndown-plugin-gfm@1.0.7` (jsDelivr) | 1,632 | 5,171 |
| `ai-agent-public.js?v=19` | 5,455 | 23,712 |
| `ai-agent-ui.js?v=19` | 22,109 | 89,588 |
| `ai-agent-ui.css?v=19` (render-blocking) | 5,401 | 25,204 |
| **Total removed from every non-Ask-Nedi page** | **1,499,906** | **5,176,850** |

`mermaid@11.16.1` was additionally redundant: `@docusaurus/theme-mermaid` already lazy-loads the
same version from the site bundle for pages that contain a diagram, so pages with diagrams were
fetching mermaid twice from two different origins.

## Mechanism on the Ask Nedi page

`loadNediAssets()` injects, in this order:

1. the `ai-agent-ui.css` `<link rel="stylesheet">`;
2. `markdown-it`, `mermaid`, `viz`, `turndown`, `turndown-plugin-gfm`, `ai-agent-public.js`,
   `ai-agent-ui.js` as `<script>` elements with `script.async = false`.

Dynamically inserted scripts are async by default. Setting `async = false` puts them on the
in-order list, which the embed needs: `ai-agent-ui.js` waits up to 5 s for `window.markdownit`
before giving up on Markdown rendering.

Version-pinned jsDelivr URLs carry `integrity` (sha384) and `crossorigin="anonymous"`. The
endpoint's own bundles are redeployed in place behind `cache-control: public, max-age=14400`, so a
pinned hash there would reject the asset after the next endpoint release; they are loaded without
integrity, matching how the product dashboard loads the same embed.

The component polls every 150 ms for `window.AiAgentChatUI` plus a compatible `window.markdownit`,
and shows:

- "Loading Ask Nedi..." while waiting;
- "Ask Nedi could not be loaded." with a **Retry** button if any asset fires `error`, if the
  dependencies are still unusable after 15 s, or if the embed constructor throws.

Retry removes the injected elements and re-injects them. Injection is guarded so repeated mounts
(SPA navigation back to the page) do not duplicate the tags.

The embed source identifier (`window.AI_AGENT_UI_SOURCE = 'learn'`) is now set immediately before
injection instead of at module evaluation, so it is always in place before `ai-agent-ui.js` runs.

## Unchanged

- Cloudflare beacon and Reo `scripts` entries.
- `@docusaurus/theme-mermaid` and its per-page mermaid lazy-loading.
- Font preloads in `stylesheets`.
- Embed configuration: `agentId`, theme sync with the Docusaurus color mode, `?q=`/`?question=` URL
  params, PostHog `nedi_question` capture, persistent container across SPA navigation, scroll
  restore.

## Verification

`npm run build:netlify` (Node 22.15.1) passes on this branch, including the rendered-title,
functional-heading, redirect-graph, rendered-link, rendered-indexability, Cloudflare-beacon and
site-build-gate checks (`"findings": []`, `"regressions": []`).

Static output, same 1,984 HTML files before and after:

| Check | `master` (dcc2885a8) | this branch |
|---|---:|---:|
| HTML files referencing `cdn.jsdelivr.net` | 1,982 | 0 |
| HTML files referencing `nedi.netdata.cloud` | 1,982 | 0 |
| HTML files with the Cloudflare beacon | 1,982 | 1,982 |
| HTML files with the Reo tag | 1,982 | 1,982 |
| `du -sb build` | 484,714,439 | 483,249,206 |

The 1,465,233-byte reduction is head markup only (~739 bytes per page); the transfer saving is the
1.5 MB of assets those tags used to request. `build/docs/ask-nedi/index.html` still contains the
`Loading Ask Nedi...` `BrowserOnly` fallback, and the endpoint URLs now appear in exactly one
runtime route chunk that no HTML file preloads.

Runtime check against the production build served locally:

- `/docs/security-and-privacy-design/netdata-agent/` (a page with a mermaid diagram):
  zero `cdn.jsdelivr.net` and zero `nedi.netdata.cloud` resource entries;
  `window.AiAgentChatUI`, `window.markdownit`, `window.Viz` and `window.TurndownService` all
  `undefined`; the diagram still renders — one `.docusaurus-mermaid-container` containing an SVG,
  produced by `theme-mermaid` from the site bundle. (`docusaurus-mermaid-container` never appears
  in static HTML on either branch: `theme-mermaid` renders `null` during SSG.)
- `/docs/ask-nedi/`: all eight elements injected in order with `async=false`, `integrity` and
  `crossorigin=anonymous` present on the five jsDelivr scripts and absent on the three endpoint
  assets; `AiAgentChatUI`, `markdownit`, `mermaid`, `Viz`, `TurndownService` and
  `TurndownPluginGfmService` all defined; `window.AI_AGENT_UI_SOURCE === 'learn'`; the embed
  mounted and reached its API; no status element left on screen. The only console errors are the
  Cloudflare RUM beacon's CORS failures, which are expected when serving from localhost.

Tests: `yarn test:run` — 418 passing across 29 files, including
`src/components/Nedi/assets.test.js` (injection order, `async=false`, integrity/crossorigin per
origin, single injection, skip when already loaded, error flag, reload) and
`src/components/Nedi/index.test.js` (loading state, readiness resolution, 15 s timeout,
asset-error failure, retry, embed-constructor failure, theme sync, scroll save/restore, embed
reuse across remounts). `assets.js` and `index.js` are both at 100% statement, branch, function
and line coverage.

On the deploy preview:

- `/docs/ask-nedi` — ask a question that returns a mermaid diagram and a DOT/Graphviz diagram, and
  use copy-as-markdown on the answer. These exercise `mermaid`, `@viz-js/viz`, `turndown` and the
  GFM plugin respectively.
- any normal docs page — the Network panel shows no `cdn.jsdelivr.net` or `nedi.netdata.cloud`
  requests.
- `/` — the 301 still lands on a working Ask Nedi page.

## Trade-off

The first visit to Ask Nedi now pays a download that used to be warm in the HTTP cache from any
previously visited docs page. Since `/` redirects to Ask Nedi, that first visit is common. The
loading state covers the wait, and every other page on the site is 1.5 MB lighter.

## Follow-up

The Nedi dependency-bump runbook lives in the embed's own repository and currently instructs
editors to update `docusaurus.config.js`. It needs to point at
`src/components/Nedi/assets.js` instead, and to note that jsDelivr version bumps also require a new
sha384 hash (`curl -s <url> | openssl dgst -sha384 -binary | openssl base64 -A`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes Nedi UI and CDN assets to Ask Nedi and declares them server‑side for that route. Previously every page fetched ~1.5 MB and Ask Nedi asset requests began after hydration; now only `/docs/ask-nedi` loads them and direct route visits request from head.

Removes site‑wide Nedi tags from `docusaurus.config.js`. `src/theme/Root/index.js` declares the `<link>`/`<script>` tags only when rendering the Ask Nedi document and mirrors the same tags on the client so hydration does not drop the stylesheet or re‑execute scripts. `src/components/Nedi/assets.js` injects CSS first, then ordered scripts (`async = false`) for client‑side entries; sets `window.AI_AGENT_UI_SOURCE = 'learn'`; adds SRI (`sha384`) and `crossorigin="anonymous"` for pinned `jsDelivr` URLs but not for endpoint bundles. The component waits for `window.AiAgentChatUI` plus a compatible `markdown-it`, times out after 15 s or on script error, and renders Retry. Retry preserves an already usable set, re‑injects only after failures, and removes a stale container if the embed constructor throws. Eliminates the redundant `mermaid` fetch; `@docusaurus/theme-mermaid` continues to lazy‑load from the site bundle. The persistent container survives SPA navigation, syncs theme, restores scroll, and captures `nedi_question` events.

- Rollout
  - On non‑Ask‑Nedi pages, confirm no requests to `cdn.jsdelivr.net` or `nedi.netdata.cloud`. On `/docs/ask-nedi`, verify head‑declared assets on direct loads and that Retry recovers asset and constructor failures.
  - When bumping dependencies, update `src/components/Nedi/assets.js` and refresh SRI for pinned `jsDelivr` URLs; keep route‑scoped tags in `src/theme/Root/index.js` aligned.

<sup>Written for commit ff975681ff84cec9c1668c6c519d0afeb6997c8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/learn/pull/2991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added route-scoped loading of Nedi chat assets.
  * Added reliable loading, retry support, and status feedback when the chat is delayed or unavailable.
  * Preserved chat sizing, focus, scrolling, theme synchronization, and analytics behavior.

* **Bug Fixes**
  * Prevented duplicate asset loading and improved recovery after failures.
  * Cleaned up chat containers when startup fails.

* **Tests**
  * Added comprehensive coverage for route detection, asset loading, retries, failures, startup, and chat interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->