### PR TITLE
Vendor IndexNow plugin dependencies v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"@docusaurus/theme-mermaid": "^3.10.2",
 		"@easyops-cn/docusaurus-search-local": "0.55.3",
 		"@mdx-js/react": "^3.1.1",
-		"@netlify/blobs": "10.7.13",
+		"@netlify/blobs": "11.0.1",
 		"@tailwindcss/typography": "^0.5.19",
 		"@types/react": "^19.2.10",
 		"acorn": "^8.14.1",

--- a/plugins/netlify-plugin-indexnow/package.json
+++ b/plugins/netlify-plugin-indexnow/package.json
@@ -4,10 +4,10 @@
   "private": true,
   "main": "index.js",
   "dependencies": {
-    "@netlify/blobs": "10.7.13",
+    "@netlify/blobs": "11.0.1",
     "saxes": "6.0.0"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22.12.0"
   }
 }

--- a/plugins/netlify-plugin-indexnow/vendor-checksums.json
+++ b/plugins/netlify-plugin-indexnow/vendor-checksums.json
@@ -3,7 +3,7 @@
   "owner": "netdata/website",
   "algorithm": "sha256",
   "dependencies": {
-    "@netlify/blobs": "10.7.13",
+    "@netlify/blobs": "11.0.1",
     "saxes": "6.0.0"
   },
   "receipt_schema_version": 2,
@@ -13,7 +13,7 @@
     "core.js": "54c5c4dd8ddb06e51daec6ed653f6cbe789d7ad9334c8b67c1acb2a25b2a7193",
     "index.js": "a9e4d1d3ede1e70cfc5d9c806bd29e29a38969b3576eef5120ee7b28f181abe1",
     "manifest.yml": "6ad2d0238e4836b0d4d8454b88fc0dd1dfafa9b2cf6197ef25d5cae71512ad6a",
-    "package.json": "ac8fb121eb21536576816db162f57ffdd99724b91dfddbce12f7cec921c0ed0b",
+    "package.json": "40647bcaa7857974d6a18abf15ec999aa28e3b185df640f4f050b675ae098442",
     "receipt-schema.json": "e4a20ce04f2cce43fa7cf5bdcf11e1dc36da284b5709f60d77843a1392fa5145"
   }
 }

--- a/scripts/verify-indexnow-vendor.js
+++ b/scripts/verify-indexnow-vendor.js
@@ -20,7 +20,7 @@ try {
     throw new Error(`IndexNow vendor contract must cover ${required}`);
   }
 
-  const expectedDependencies = {'@netlify/blobs': '10.7.13', saxes: '6.0.0'};
+  const expectedDependencies = {'@netlify/blobs': '11.0.1', saxes: '6.0.0'};
   if (JSON.stringify(contract.dependencies) !== JSON.stringify(expectedDependencies)) {
     throw new Error('IndexNow vendor dependency contract is invalid');
   }
@@ -28,6 +28,9 @@ try {
     fs.readFileSync(path.join(pluginDirectory, 'package.json'), 'utf8'),
   );
   const rootPackage = JSON.parse(fs.readFileSync(path.resolve('package.json'), 'utf8'));
+  if (pluginPackage.engines?.node !== '>=22.12.0') {
+    throw new Error('IndexNow plugin must require the Node runtime supported by @netlify/blobs');
+  }
   for (const [name, version] of Object.entries(expectedDependencies)) {
     if (pluginPackage.dependencies?.[name] !== version || rootPackage.dependencies?.[name] !== version) {
       throw new Error(`IndexNow dependency ${name} must be pinned to ${version} in both package files`);

--- a/src/seo/deploymentIntegrations.test.js
+++ b/src/seo/deploymentIntegrations.test.js
@@ -91,7 +91,7 @@ describe('shared deployment integrations', () => {
       schema_version: 2,
       owner: 'netdata/website',
       algorithm: 'sha256',
-      dependencies: {'@netlify/blobs': '10.7.13', saxes: '6.0.0'},
+      dependencies: {'@netlify/blobs': '11.0.1', saxes: '6.0.0'},
       receipt_schema_version: 2,
       contract_tests_schema_version: 2,
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3307,24 +3307,24 @@
   dependencies:
     "@tybys/wasm-util" "^0.10.3"
 
-"@netlify/blobs@10.7.13":
-  version "10.7.13"
-  resolved "https://registry.yarnpkg.com/@netlify/blobs/-/blobs-10.7.13.tgz#89f02955c698fff7d2a5d32e34f5cd3c45ad1c0d"
-  integrity sha512-LJnmGtQQ2/NdTo0Cm+YP2xR1vtRle6V3kkzMrAOJgRm1SEFOJOcaAFQrth7RnbxCH/IzCM8QakTaCHHKY+K2qA==
+"@netlify/blobs@11.0.1":
+  version "11.0.1"
+  resolved "https://registry.npmjs.org/@netlify/blobs/-/blobs-11.0.1.tgz#5babab4745f38def2823346945b9c6d0975a0f96"
+  integrity sha512-ohmcoesUSdIU6FSZhq4EwDu6sYBWrfywRQdyUOYo/a7Rnc1VLot8w2d0npQzr/YuRgJFqV50OZ0Eg3GOCnRUcQ==
   dependencies:
-    "@netlify/dev-utils" "5.0.0"
-    "@netlify/otel" "^6.0.6"
-    "@netlify/runtime-utils" "2.3.0"
+    "@netlify/dev-utils" "6.0.1"
+    "@netlify/otel" "^7.0.1"
+    "@netlify/runtime-utils" "3.0.0"
 
-"@netlify/dev-utils@5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@netlify/dev-utils/-/dev-utils-5.0.0.tgz#495c07ed4f089220df768e6f719848013ad2fa57"
-  integrity sha512-ICAsnvbJW9Dv9PGfmJGdjMBsX6uXdJxrA76QE3l3rnGKL5ZcyaA2cJZXacdEmE2ZmtkiVhEJogM15a9nK/ZxDw==
+"@netlify/dev-utils@6.0.1":
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/@netlify/dev-utils/-/dev-utils-6.0.1.tgz#1b8059b098494312c49308179301af5177c5cdc2"
+  integrity sha512-q5g70dO3q/M/XTBQz7uIECJxVlJoS8UBlzpjf22DV6q61UzXa8EONTPXPmvisrFcUi1I3AUKplPcHGQYZZj+Vw==
   dependencies:
     "@whatwg-node/server" "^0.11.0"
     ansis "^4.1.0"
     atomically "^2.0.3"
-    chokidar "^4.0.1"
+    chokidar "^5.0.0"
     decache "^4.6.2"
     dettle "^1.0.5"
     dot-prop "9.0.0"
@@ -3333,10 +3333,10 @@
     parse-gitignore "^2.0.0"
     semver "^7.7.2"
 
-"@netlify/otel@^6.0.6":
-  version "6.0.6"
-  resolved "https://registry.yarnpkg.com/@netlify/otel/-/otel-6.0.6.tgz#668d5be402e5a1179bbe3a64f82d169d040ad255"
-  integrity sha512-KpiJ8c4V4GvgpQH5E1axg43kYdIN9saToLbzvgrDzPun4XMGwz/tLfoIkwJ4jwrVmbPj35+8+dj3gkggQAtjtg==
+"@netlify/otel@^7.0.1":
+  version "7.0.1"
+  resolved "https://registry.npmjs.org/@netlify/otel/-/otel-7.0.1.tgz#a2e3e92df6594c53180b8029d75bb28d28fabe2d"
+  integrity sha512-9GVV5b/Fb1nfXbooy46YcR6YrzTV0wjTC70y4Em6xgcckpvgi5F9hWQssl7UGIMp0abx9WxTAz2LPITTCnarKQ==
   dependencies:
     "@opentelemetry/api" "1.9.1"
     "@opentelemetry/core" "2.8.0"
@@ -3344,10 +3344,10 @@
     "@opentelemetry/resources" "2.9.0"
     "@opentelemetry/sdk-trace-node" "2.9.0"
 
-"@netlify/runtime-utils@2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@netlify/runtime-utils/-/runtime-utils-2.3.0.tgz#56dd62b7286a04182e118226aab28dd63ee67022"
-  integrity sha512-cW8weDvsKV7zfia2m5EcBy6KILGoPD+eYZ3qWNGnIo05DGF28goPES0xKSDkNYgAF/2rRSIhie2qcBhbGVgSRg==
+"@netlify/runtime-utils@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/@netlify/runtime-utils/-/runtime-utils-3.0.0.tgz#41866acfa9472e32025f9cafa97cdb8c4c4d92fc"
+  integrity sha512-OHo40+V3QZkR+UrDjqhN+LekrAby/dSSJxsvyYs9i88E/mSl3goB/ysoL+VYROm190egxmQyRYlHK7vL4GeHBQ==
 
 "@noble/hashes@1.4.0":
   version "1.4.0"
@@ -6591,12 +6591,12 @@ chokidar@^3.5.3, chokidar@^3.6.0:
   optionalDependencies:
     fsevents "~2.3.2"
 
-chokidar@^4.0.1:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-4.0.3.tgz#7be37a4c03c9aee1ecfe862a4a23b2c70c205d30"
-  integrity sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==
+chokidar@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz#949c126a9238a80792be9a0265934f098af369a5"
+  integrity sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==
   dependencies:
-    readdirp "^4.0.1"
+    readdirp "^5.0.0"
 
 chrome-trace-event@^1.0.2:
   version "1.0.4"
@@ -12634,10 +12634,10 @@ readable-stream@^3.0.6:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
-readdirp@^4.0.1:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-4.1.2.tgz#eb85801435fbf2a7ee58f19e0921b068fc69948d"
-  integrity sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==
+readdirp@^5.0.0:
+  version "5.1.1"
+  resolved "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz#520bca06f9d1ae1b96cc0800dbe84b983d19422c"
+  integrity sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==
 
 readdirp@~3.6.0:
   version "3.6.0"


### PR DESCRIPTION
## Summary

- vendors the exact IndexNow v11 dependency contract from `netdata/website@d71547ec7340972f515e5adc9e0c527ffead87b0`
- updates both plugin and root pins to `@netlify/blobs` 11.0.1, retains `saxes` 6.0.0, and requires Node `>=22.12.0` as specified by the owner artifact
- copies the owner checksum contract and verifier byte-for-byte; the Learn integration assertion now expects the same dependency contract

The six owner-covered files all match the supplied SHA-256 values:

- `contract-tests.json`: `ee42ff0683ed74dd969a4394fd357bc477e3fddcefe0b1821d33d3a036c0e882`
- `core.js`: `54c5c4dd8ddb06e51daec6ed653f6cbe789d7ad9334c8b67c1acb2a25b2a7193`
- `index.js`: `a9e4d1d3ede1e70cfc5d9c806bd29e29a38969b3576eef5120ee7b28f181abe1`
- `manifest.yml`: `6ad2d0238e4836b0d4d8454b88fc0dd1dfafa9b2cf6197ef25d5cae71512ad6a`
- `package.json`: `40647bcaa7857974d6a18abf15ec999aa28e3b185df640f4f050b675ae098442`
- `receipt-schema.json`: `e4a20ce04f2cce43fa7cf5bdcf11e1dc36da284b5709f60d77843a1392fa5145`

## Validation

- local Node `v22.23.2` satisfies the vendored `>=22.12.0` engine; installed `@netlify/blobs` reports 11.0.1
- `node scripts/verify-indexnow-vendor.js`
- `yarn test:run` — 435 Vitest assertions, 64 IndexNow checks, and all site-build-gate tests
- `yarn build:netlify` twice — all build/post-build gates passed; 4,157 output files were byte-identical (manifest SHA-256 `31d383763b1f35166873c2b31aa114eedbca8568c8fb1cab57b5256ca544cb76`)

## Merge dependency

This is intentionally based directly on `master`, not a stacked branch. Merge #2997 first, then rebase this PR onto the resulting `master`: #2997 removes the obsolete root `package-lock.json` and establishes the root Yarn authority. Until then, frozen Yarn installation passes but emits the known mixed-lockfile warning from the unchanged base file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Vendors the IndexNow v11 contract and aligns the Learn plugin and root to `@netlify/blobs` 11.0.1, now requiring Node >=22.12.0. This keeps the integration byte-for-byte with the owner artifact and updates verification and tests to the new dependency contract.

- Copies the owner checksum contract (six files) and updates `vendor-checksums.json`; expected deps are `{'@netlify/blobs': '11.0.1', 'saxes': '6.0.0'}`.
- Pins `@netlify/blobs` 11.0.1 in both root and plugin `package.json`, updates `yarn.lock`, and adjusts tests to assert the new contract; no functional changes beyond the Node engine bump.
- Tightens `scripts/verify-indexnow-vendor.js` to enforce the pins in both packages and require Node `>=22.12.0`.
- Migration: use Node `>=22.12.0` locally and in CI.
- Merge dependency: merge #2997 first, then rebase this PR to clear the mixed-lockfile warning.

<sup>Written for commit 372a203cb2bfb6672c4f0422c2bbaaa2cd049585. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/learn/pull/2998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

