### PR TITLE
Refresh Learn Node runtime pins

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "image": "node:16", 
+    "image": "node:22.23.2",
     "extensions":[
 		"DavidAnson.vscode-markdownlint"
 	],

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
 [build]
   command = "npm run build:netlify"
   publish = "build"
-  environment = { NPM_VERSION = "10.9.2", NODE_VERSION = "22.14.0", NODE_OPTIONS = "--max-old-space-size=3072", DOCUSAURUS_SSR_CONCURRENCY = "4"}
+  environment = { NPM_VERSION = "10.9.8", NODE_VERSION = "22.23.2", NODE_OPTIONS = "--max-old-space-size=3072", DOCUSAURUS_SSR_CONCURRENCY = "4"}
 
 [[plugins]]
   package = "./plugins/netlify-plugin-indexnow"

--- a/src/seo/deploymentIntegrations.test.js
+++ b/src/seo/deploymentIntegrations.test.js
@@ -51,9 +51,16 @@ describe('shared deployment integrations', () => {
     for (const relative of ['static.toml', 'netlify.toml']) {
       const config = fs.readFileSync(path.join(root, relative), 'utf8');
       expect(config).not.toContain('NETLIFY_USE_YARN');
-      expect(config).toContain('NODE_VERSION = "22.14.0"');
-      expect(config).toContain('NPM_VERSION = "10.9.2"');
+      expect(config).toContain('NODE_VERSION = "22.23.2"');
+      expect(config).toContain('NPM_VERSION = "10.9.8"');
     }
+  });
+
+  it('aligns the development container with the pinned production Node runtime', () => {
+    const devcontainer = JSON.parse(
+      fs.readFileSync(path.join(root, '.devcontainer/devcontainer.json'), 'utf8'),
+    );
+    expect(devcontainer.image).toBe('node:22.23.2');
   });
 
   it('uses the stable Docusaurus Faster engine within the Netlify memory bound', () => {

--- a/static.toml
+++ b/static.toml
@@ -3,7 +3,7 @@
 [build]
   command = "npm run build:netlify"
   publish = "build"
-  environment = { NPM_VERSION = "10.9.2", NODE_VERSION = "22.14.0", NODE_OPTIONS = "--max-old-space-size=3072", DOCUSAURUS_SSR_CONCURRENCY = "4"}
+  environment = { NPM_VERSION = "10.9.8", NODE_VERSION = "22.23.2", NODE_OPTIONS = "--max-old-space-size=3072", DOCUSAURUS_SSR_CONCURRENCY = "4"}
 
 [[plugins]]
   package = "./plugins/netlify-plugin-indexnow"


### PR DESCRIPTION
## Summary

- pins Netlify builds to Node 22.23.2 and npm 10.9.8 in both the maintained `static.toml` source section and generated `netlify.toml`
- upgrades the development container from unmaintained Node 16 to the same exact `node:22.23.2` runtime
- adds a deployment integration assertion that keeps local and production runtime pins aligned

Node 22.23.2 is the current Node 22 LTS release and bundles npm 10.9.8. The Docker `node:22.23.2` manifest resolves successfully, and the local runtime used for validation is that exact Node/npm pair.

## Validation

- parsed the devcontainer JSON and verified the Docker image tag exists
- `yarn test:run` — 436 Vitest assertions, 64 IndexNow checks, and all site-build-gate tests
- `yarn build:netlify` twice — all build/post-build gates passed; 4,157 output files were byte-identical (manifest SHA-256 `31d383763b1f35166873c2b31aa114eedbca8568c8fb1cab57b5256ca544cb76`)

No public routes, generated content, redirect, sitemap, robots, or indexability policy changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins Netlify builds to Node 22.23.2 and npm 10.9.8 and aligns the devcontainer to the same runtime for reproducible local and production builds. Previously builds used Node 22.14.0/npm 10.9.2 and the devcontainer ran Node 16.

- Updates `static.toml` and `netlify.toml` `environment` to NODE_VERSION "22.23.2" and NPM_VERSION "10.9.8".
- Updates `.devcontainer/devcontainer.json` to use `node:22.23.2`.
- Adds a test in `src/seo/deploymentIntegrations.test.js` that enforces runtime alignment across configs.
- No content, routing, or SEO policy changes expected.

<sup>Written for commit 40abec105ead60b26b96f4fdd128fc9763e3641a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/learn/pull/2999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

