### PR TITLE
Use TypeScript 6 for Learn tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 		"remark-gfm": "^4.0.1",
 		"saxes": "6.0.0",
 		"swagger-ui": "^5.32.14",
-		"typescript": "^5.9.3",
+		"typescript": "^6.0.3",
 		"webpack": "^5.109.2"
 	},
 	"devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14074,10 +14074,10 @@ types-ramda@^0.30.1:
   dependencies:
     ts-toolbelt "^9.6.0"
 
-typescript@^5.9.3:
-  version "5.9.3"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz"
-  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+typescript@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
+  integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
 
 ua-parser-js@^1.0.37:
   version "1.0.41"


### PR DESCRIPTION
## Summary

- Upgrade the root TypeScript dependency from 5.9.3 to 6.0.3.
- Preserve the JavaScript compiler API and tsserver executable used by MDX-compatible tooling.
- Keep the root Yarn lockfile on the repository's existing npmjs provenance.

## Compatibility rationale

TypeScript 6 is the stable transition release and remains API-compatible with TypeScript 5.9. TypeScript 7.0 does not expose a stable programmatic API, and Microsoft recommends that MDX projects remain on TypeScript 6 until that support is available.

- https://devblogs.microsoft.com/typescript/announcing-typescript-6-0/
- https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#typescript-and-embedded-languages

Learn currently has no TypeScript source files or tsconfig. This update aligns the direct tooling dependency without changing the site runtime or rendered content.

## Validation

- TypeScript 6.0.3 compiler API and tsserver availability verified.
- yarn install --frozen-lockfile passed.
- yarn check --integrity passed.
- yarn test:run passed: 436 Vitest, 64 IndexNow, 2 Swagger UI vendor, 3 dependency-authority, and 4 site-gate tests.
- Two yarn build:netlify runs passed: 1,984 HTML files, 1,978 indexed pages, and zero site-gate findings or regressions.
- Both production builds produced the same complete rendered-output digest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade root `typescript` from 5.9.3 to 6.0.3 to align Learn’s tooling with the stable transition release. Keeps the compiler API and `tsserver` used by MDX tooling while avoiding TypeScript 7’s unstable programmatic API; no changes to site runtime or rendered output.

**Review notes**
- Only `package.json` and `yarn.lock` changed; lockfile remains on npmjs provenance.
- Validation passed: install checks, full test suite, and two Netlify builds produced identical output digests.
- No migration required.

<sup>Written for commit 0d0335af87f808ff25367f181d151ecd4ef5bd46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/learn/pull/3030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the TypeScript development dependency to version 6.0.3.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->