### PR TITLE
Document link validation enforcement boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# Netdata Learn Working Rules
+
+## Repository purpose
+
+This repository builds `learn.netdata.cloud` with Docusaurus and deploys the static result through
+Netlify. Public-route validation must use rendered output; source Markdown alone is not proof that
+a published path or fragment exists.
+
+## Link integrity contract
+
+Implementation status: policy specified; enforcement is unsupported until the standalone GitHub
+jobs and corresponding branch-protection settings exist.
+
+Link validation has four distinct failure domains. Do not collapse them into one job or make a
+Netlify build or deployment responsible for merge eligibility:
+
+- **Same-site links:** rendered links whose destination is `learn.netdata.cloud`, including
+  relative links, must resolve to an existing rendered path and fragment in the Learn build.
+  Validate them in a standalone required GitHub job outside Netlify. A same-site failure blocks
+  merging, while the deploy preview remains available.
+- **Cross-Netdata-site links:** rendered links to another Netdata-owned site, including
+  `www.netdata.cloud`, run in a distinct standalone advisory GitHub job outside Netlify. Findings
+  remain visible but cannot block merging or deployment because coordinated source and target pull
+  requests may merge in either order.
+- **New third-party links:** a third-party target URL present in the pull-request rendered output
+  but absent from the merge-base rendered output runs in a separate standalone advisory GitHub job
+  outside Netlify. The pull-request job checks only these newly introduced targets; its findings
+  cannot block merging or deployment.
+- **Complete third-party reconciliation:** the full rendered third-party link inventory is checked
+  by a weekly scheduled job, not by every pull request. Workflow ownership, confirmation policy,
+  issue lifecycle, request policy, and optional AI-assisted repair require explicit user decisions
+  before implementation.
+
+## Change discipline
+
+- Keep the required same-site job independent from the advisory cross-site and third-party jobs.
+- Do not weaken Docusaurus or CI link enforcement to make a pull request pass. Repair the owning
+  source or its generator.
+- Generated documentation must be repaired through its owning producer and normal ingestion path;
+  do not hand-edit output that regeneration will replace.
+- Use explicit file paths when staging changes; never stage the whole worktree.


### PR DESCRIPTION
## Summary

- add the root Learn agent instructions
- define same-site links as a required standalone merge check
- define cross-Netdata-site links as a separate advisory check
- check only newly introduced third-party targets advisorially on pull requests
- reserve complete third-party reconciliation for a weekly job with unresolved automation decisions
- keep every link check independent from Netlify

## Validation

- `git diff --check`
- documentation-only change; no workflow, branch-protection, Netlify, or public-site behavior changed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents Learn link integrity enforcement and keeps link checks independent from Netlify. This sets required vs advisory jobs without changing workflows yet.

- Validate same-site links against rendered Learn output in a standalone required GitHub job; failures block merges but not deploy previews.
- Run cross-Netdata-site link checks in a separate advisory job; findings cannot block merges or deployments.
- On pull requests, check only newly introduced third‑party targets in an advisory job; reconcile the full third‑party inventory weekly.
- Validate public routes using rendered output, not source Markdown; fix issues in the owning source or generator.
- Enforcement is pending; standalone jobs and branch protection will be added later. This PR adds documentation only.

<sup>Written for commit db8270e20c0f278c70bb30c9773b0f5441c4416a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/learn/pull/3031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added repository guidance for maintaining the Netdata Learn documentation site.
  * Documented link validation rules, third-party link checks, implementation-status requirements, and change-management practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->