### PR TITLE
Keep link validation repository-local

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,13 @@ a published path or fragment exists.
 Implementation status: policy specified; enforcement is unsupported until the standalone GitHub
 jobs and corresponding branch-protection settings exist.
 
+Learn link validation is repository-owned and self-contained. This repository owns its checker
+code, fixtures, workflows, schedule, artifacts, issue maintenance, branch-protection integration,
+repair automation, implementation plan, and validation evidence. No Learn link-validation job may
+fetch, import, vendor, or execute production code from `netdata/seo`, and Learn CI must not require
+an SEO checkout, workflow, artifact, service, or repository permission. SEO may consume published
+results for measurement, but it is never a production dependency.
+
 Link validation has four distinct failure domains. Do not collapse them into one job or make a
 Netlify build or deployment responsible for merge eligibility:
 
@@ -27,9 +34,9 @@ Netlify build or deployment responsible for merge eligibility:
   outside Netlify. The pull-request job checks only these newly introduced targets; its findings
   cannot block merging or deployment.
 - **Complete third-party reconciliation:** the full rendered third-party link inventory is checked
-  by a weekly scheduled job, not by every pull request. Workflow ownership, confirmation policy,
-  issue lifecycle, request policy, and optional AI-assisted repair require explicit user decisions
-  before implementation.
+  by a Learn-owned weekly scheduled job, not by every pull request. Its issue and any repair pull
+  request stay in this repository. Confirmation policy, issue lifecycle behavior, request policy,
+  and optional AI-assisted repair require explicit user decisions before implementation.
 
 ## Change discipline
 


### PR DESCRIPTION
## Summary

- make Learn the sole owner of its link checker, workflows, schedules, artifacts, issues, permissions, and repair automation
- prohibit Learn link validation from depending on production code or services in `netdata/seo`
- keep the weekly audit and any repair pull requests inside this repository

## Validation

- `git diff --check`
- documentation-only change; no workflow, Netlify, branch-protection, or public-site behavior changed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets policy that Learn link validation is repository-owned and self-contained, and must not depend on `netdata/seo` production code or services. Previously implicit ownership/dependencies are now explicit: the weekly audit and any repair PRs stay in this repository. No workflow, Netlify, branch-protection, or public-site behavior changes.

<sup>Written for commit fd63bda8c38bba589e6a49247c1124253c24aa58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/learn/pull/3032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

