### PR TITLE
Repair Energomera redirect transition

### DIFF
--- a/ingest/test_legacy_redirect_gate.py
+++ b/ingest/test_legacy_redirect_gate.py
@@ -366,6 +366,9 @@ class RepositoryCatalogueTests(unittest.TestCase):
             "https://github.com/netdata/netdata/blob/master/"
             "src/go/plugin/go.d/collector/prometheus/README.md"
         )
+        prometheus_route = (
+            "/docs/collecting-metrics/collectors/applications/prometheus-endpoint"
+        )
         routes = {
             "/docs/data-collection/iot-devices/energomera-smart-power-meters",
             "/docs/collecting-metrics/iot-devices/energomera-smart-power-meters",
@@ -376,6 +379,14 @@ class RepositoryCatalogueTests(unittest.TestCase):
         result = self.gate()
         for route in routes:
             self.assertIn(route, result["resolved"])
+            self.assertEqual(result["resolved"][route], prometheus_route)
+
+        merged = redirects.combineDictsOverwrite(
+            redirects.readRedirectsFromFile(str(REPO_ROOT / "netlify.toml")),
+            result["resolved"],
+        )
+        for route in routes:
+            self.assertEqual(merged[route], prometheus_route)
 
     def test_policy_retirements_are_complete_and_match_the_catalogue(self):
         retirements = self.policy["legacy_catalogue_retirements"]

--- a/netlify.toml
+++ b/netlify.toml
@@ -6157,7 +6157,7 @@
 
 [[redirects]]
   from="/docs/data-collection/iot-devices/energomera-smart-power-meters"
-  to="/docs/collecting-metrics/collectors/hardware-and-sensors/energomera-smart-power-meters"
+  to="/docs/collecting-metrics/collectors/applications/prometheus-endpoint"
 
 [[redirects]]
   from="/docs/data-collection/iot-devices/craftbeerpi"
@@ -9417,7 +9417,7 @@
 
 [[redirects]]
   from="/docs/collecting-metrics/iot-devices/energomera-smart-power-meters"
-  to="/docs/collecting-metrics/collectors/hardware-and-sensors/energomera-smart-power-meters"
+  to="/docs/collecting-metrics/collectors/applications/prometheus-endpoint"
 
 [[redirects]]
   from="/docs/collecting-metrics/iot-devices/elgato-key-light-devices."
@@ -10465,7 +10465,7 @@
 
 [[redirects]]
   from="/docs/collecting-metrics/hardware-and-iot/energomera-smart-power-meters"
-  to="/docs/collecting-metrics/collectors/hardware-and-sensors/energomera-smart-power-meters"
+  to="/docs/collecting-metrics/collectors/applications/prometheus-endpoint"
 
 [[redirects]]
   from="/docs/collecting-metrics/hardware-and-iot/elgato-key-light-devices."
@@ -11681,7 +11681,7 @@
 
 [[redirects]]
   from="/docs/collecting-metrics/hardware-and-sensors/energomera-smart-power-meters"
-  to="/docs/collecting-metrics/collectors/hardware-and-sensors/energomera-smart-power-meters"
+  to="/docs/collecting-metrics/collectors/applications/prometheus-endpoint"
 
 [[redirects]]
   from="/docs/collecting-metrics/hardware-and-sensors/elgato-key-light-devices."


### PR DESCRIPTION
## Result

- routes all four historical Energomera URLs to the generic Prometheus collector
- aligns the generated Netlify redirect state with the catalogue migration merged in #3036
- adds a regression assertion that the catalogue-derived redirects merge without a deployment-identity conflict

## Technical reason

The tracked dynamic redirects still targeted the retired Energomera page. After #3036 changed the legacy catalogue to the Prometheus source, ingestion correctly resolved the replacement but rejected the conflicting tracked target before it could regenerate `netlify.toml`.

The fail-closed conflict behavior remains unchanged. Only the four known generated targets are reconciled.

## Validation

- 16 focused redirect cleanup and catalogue tests pass
- redirect generation completes with 3,534 resolved catalogue entries, one reviewed retirement, and zero retained stale entries
- generated diff is limited to the four Energomera targets
- `git diff --check` passes

The repository-wide redirect test currently has an unrelated existing eBPF DCstat fixture-count failure: the catalogue contains four matching routes while the test expects three. The same failure reproduces on the merged #3036 tree.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repairs the Energomera redirect transition by routing four historical Energomera URLs to the generic Prometheus collector. Previously these URLs targeted a retired Energomera page and triggered a fail-closed conflict; now they resolve to the Prometheus endpoint and merge cleanly with tracked redirects.

- Limits `netlify.toml` changes to the four Energomera entries; no other redirects change.
- Adds a test that asserts the catalogue resolves these routes to `/docs/collecting-metrics/collectors/applications/prometheus-endpoint` and that merging with existing redirects has no deployment-identity conflict.
- Keeps the fail-closed policy; only these four known targets are reconciled.

<sup>Written for commit 20263c0e2440574bfc9ff89201ba88db55a8761e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/learn/pull/3037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

