### PR TITLE
Preserve the published Energomera documentation route

### DIFF
--- a/ingest/test_legacy_redirect_gate.py
+++ b/ingest/test_legacy_redirect_gate.py
@@ -375,6 +375,10 @@ class RepositoryCatalogueTests(unittest.TestCase):
             "/docs/collecting-metrics/hardware-and-iot/energomera-smart-power-meters",
             "/docs/collecting-metrics/hardware-and-sensors/energomera-smart-power-meters",
         }
+        published_route = (
+            "/docs/collecting-metrics/collectors/hardware-and-sensors/"
+            "energomera-smart-power-meters"
+        )
         self.assertEqual({self.catalogue[route] for route in routes}, {prometheus_source})
         result = self.gate()
         for route in routes:
@@ -385,7 +389,7 @@ class RepositoryCatalogueTests(unittest.TestCase):
             redirects.readRedirectsFromFile(str(REPO_ROOT / "netlify.toml")),
             result["resolved"],
         )
-        for route in routes:
+        for route in routes | {published_route}:
             self.assertEqual(merged[route], prometheus_route)
 
     def test_policy_retirements_are_complete_and_match_the_catalogue(self):

--- a/netlify.toml
+++ b/netlify.toml
@@ -11684,6 +11684,10 @@
   to="/docs/collecting-metrics/collectors/applications/prometheus-endpoint"
 
 [[redirects]]
+  from="/docs/collecting-metrics/collectors/hardware-and-sensors/energomera-smart-power-meters"
+  to="/docs/collecting-metrics/collectors/applications/prometheus-endpoint"
+
+[[redirects]]
   from="/docs/collecting-metrics/hardware-and-sensors/elgato-key-light-devices."
   to="/docs/collecting-metrics/collectors/hardware-and-sensors/elgato-key-light-devices."
 


### PR DESCRIPTION
## Summary

- Redirect the removed generated Energomera collector route directly to the generic Prometheus collector page.
- Extend the existing Energomera redirect regression test to cover the generated page's own public URL.

## Why

The four historical Energomera aliases already resolve to the generic Prometheus collector, but the generated page's immediately preceding public route returned HTTP 404 after the source was removed.

## Validation

- Existing Energomera redirect regression test: passed
- Production Netlify build and post-build gates: passed across 1,986 HTML files
- Site build gate v9: zero findings and regressions
- Required same-site links: 46,754 checked, zero failures, zero warnings
- `git diff --check`

## Unrelated evidence

The complete legacy-redirect test module also exposes an existing DCstat catalogue assertion: four recorded routes now exist while the assertion still expects three. This PR does not change DCstat sources, routes, or catalogue behavior.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the published Energomera collector route by redirecting it to the generic Prometheus collector page, preventing 404s after the Energomera source was removed. Previously, the published route returned 404; now it redirects to the Prometheus collector without altering other routes.

- Adds a Netlify redirect from /docs/collecting-metrics/collectors/hardware-and-sensors/energomera-smart-power-meters to /docs/collecting-metrics/collectors/applications/prometheus-endpoint.
- Extends the Energomera redirect regression test to assert the published route maps to the Prometheus page alongside the four historical aliases.

<sup>Written for commit 17b10bd5a967b1102ae268af491a298467debf0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/learn/pull/3041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the retired Energomera hardware and sensors documentation route to redirect to the Prometheus collector documentation.
  * Ensured both supported URL variants resolve consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->