### PR TITLE
Run rendered link checks for automated ingest PRs

### DIFF
--- a/.github/workflows/ingest.yml
+++ b/.github/workflows/ingest.yml
@@ -23,6 +23,12 @@ env:
   # Assignees for broken links issues (all repos)
   BROKEN_LINKS_ASSIGNEES: "kanelatechnical,ilyam8"
 
+permissions:
+  actions: write
+  contents: write
+  issues: write
+  pull-requests: write
+
 jobs:
   ingest:
     runs-on: ubuntu-latest
@@ -87,6 +93,7 @@ jobs:
           mv tmp "${docfile}" || exit 1
 
       - name: Create pull request
+        id: create-pr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -100,6 +107,42 @@ jobs:
             [1]: https://github.com/peter-evans/create-pull-request:
           branch: ingest
           labels: ingest, automation
+
+      - name: Run rendered link checks for the automated PR
+        if: >-
+          steps.create-pr.outputs.pull-request-operation == 'created' ||
+          steps.create-pr.outputs.pull-request-operation == 'updated'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PULL_REQUEST_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pullNumber = Number(process.env.PULL_REQUEST_NUMBER);
+            if (!Number.isSafeInteger(pullNumber) || pullNumber <= 0) {
+              throw new Error(`Invalid pull-request number: ${process.env.PULL_REQUEST_NUMBER}`);
+            }
+
+            const { data: pull } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullNumber,
+            });
+            if (pull.head.repo.full_name !== `${context.repo.owner}/${context.repo.repo}`) {
+              throw new Error(`Refusing to dispatch checks for external head repository ${pull.head.repo.full_name}`);
+            }
+
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'rendered-link-integrity.yml',
+              ref: pull.head.ref,
+              inputs: {
+                pr_number: String(pull.number),
+                base_sha: pull.base.sha,
+                head_sha: pull.head.sha,
+              },
+            });
 
       - name: Create or update broken links issue
         if: steps.ingest.outputs.has_broken_links == 'true'

--- a/.github/workflows/rendered-link-integrity.yml
+++ b/.github/workflows/rendered-link-integrity.yml
@@ -3,12 +3,26 @@ name: Rendered link integrity
 on:
   pull_request:
   merge_group:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request that owns the dispatched checks
+        required: true
+        type: string
+      base_sha:
+        description: Pull-request base revision
+        required: true
+        type: string
+      head_sha:
+        description: Pull-request head revision
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 concurrency:
-  group: rendered-link-integrity-${{ github.event.pull_request.number || github.event.merge_group.head_sha }}
+  group: rendered-link-integrity-${{ inputs.pr_number || github.event.pull_request.number || github.event.merge_group.head_sha }}
   cancel-in-progress: true
 
 env:
@@ -26,7 +40,7 @@ jobs:
       - name: Check out the pull-request revision with history
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+          ref: ${{ inputs.head_sha || github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -80,7 +94,7 @@ jobs:
       - name: Check out checker code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+          ref: ${{ inputs.head_sha || github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
           persist-credentials: false
 
       - name: Set up Node.js
@@ -126,7 +140,7 @@ jobs:
       - name: Check out checker code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+          ref: ${{ inputs.head_sha || github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
           persist-credentials: false
 
       - name: Set up Node.js
@@ -168,7 +182,7 @@ jobs:
       - name: Check out the pull-request revision with history
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+          ref: ${{ inputs.head_sha || github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -180,8 +194,8 @@ jobs:
 
       - name: Switch to the merge-base revision
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+          BASE_SHA: ${{ inputs.base_sha || github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          HEAD_SHA: ${{ inputs.head_sha || github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
         run: |
           merge_base=$(git merge-base "$BASE_SHA" "$HEAD_SHA")
           test -n "$merge_base"
@@ -235,7 +249,7 @@ jobs:
       - name: Check out checker code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+          ref: ${{ inputs.head_sha || github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
           persist-credentials: false
 
       - name: Set up Node.js

--- a/ingest/test_legacy_redirect_gate.py
+++ b/ingest/test_legacy_redirect_gate.py
@@ -355,11 +355,29 @@ class RepositoryCatalogueTests(unittest.TestCase):
 
     def test_ebpf_dcstat_routes_are_resolved_or_retained_across_the_upstream_move(self):
         result = self.gate()
-        routes = {route for route, source in self.catalogue.items() if source.endswith("integrations/ebpf_dcstat.md")}
+        source = (
+            "https://github.com/netdata/netdata/blob/master/"
+            "src/collectors/ebpf.plugin/ebpfgo.plugin/integrations/ebpf_dcstat.md"
+        )
+        routes = {
+            route
+            for route, catalogue_source in self.catalogue.items()
+            if catalogue_source == source
+        }
         self.assertEqual(len(routes), 3)
         retained = {entry["route"] for entry in result["retained"]}
         for route in routes:
             self.assertTrue(route in result["resolved"] or route in retained, route)
+
+        canonical_route = "/docs/collecting-metrics/collectors/operating-systems/ebpf-dcstat"
+        final_redirects = redirects.clean_redirects(
+            redirects.combineDictsOverwrite(
+                redirects.readRedirectsFromFile(str(REPO_ROOT / "netlify.toml")),
+                result["resolved"],
+            ),
+            set(self.mapping.values()),
+        )
+        self.assertNotIn(canonical_route, final_redirects)
 
     def test_retired_energomera_routes_resolve_to_generic_prometheus_collector(self):
         prometheus_source = (

--- a/tests/link_integrity.test.mjs
+++ b/tests/link_integrity.test.mjs
@@ -369,6 +369,9 @@ test('keeps required and advisory jobs standalone, pinned, and outside Netlify',
   ]) assert.match(workflow, new RegExp(`name: ${name}`));
   assert.match(workflow, /same-site:\n[\s\S]*?needs: render-head\n\s+if: \$\{\{ always\(\) \}\}/);
   assert.match(workflow, /merge_group:/);
+  assert.match(workflow, /workflow_dispatch:\n\s+inputs:\n\s+pr_number:/);
+  assert.match(workflow, /inputs\.head_sha \|\| github\.event\.pull_request\.head\.sha/);
+  assert.match(workflow, /inputs\.base_sha \|\| github\.event\.pull_request\.base\.sha/);
   assert.ok(
     workflow.indexOf('Preserve the pull-request checker for the base render') <
     workflow.indexOf('Switch to the merge-base revision'),
@@ -378,4 +381,17 @@ test('keeps required and advisory jobs standalone, pinned, and outside Netlify',
     .filter((reference) => !/@[0-9a-f]{40}$/.test(reference));
   assert.deepEqual(unpinned, []);
   assert.doesNotMatch(netlify, /link-integrity|same-site links|third-party links/i);
+});
+
+test('ingest automation explicitly dispatches rendered link checks for its PR head', async () => {
+  const root = path.resolve(import.meta.dirname, '..');
+  const workflow = await fs.readFile(path.join(root, '.github/workflows/ingest.yml'), 'utf8');
+  assert.match(workflow, /permissions:\n\s+actions: write/);
+  assert.match(workflow, /id: create-pr\n\s+uses: peter-evans\/create-pull-request@[0-9a-f]{40}/);
+  assert.match(workflow, /pull-request-operation == 'created'/);
+  assert.match(workflow, /pull-request-operation == 'updated'/);
+  assert.match(workflow, /workflow_id: 'rendered-link-integrity\.yml'/);
+  assert.match(workflow, /ref: pull\.head\.ref/);
+  assert.match(workflow, /base_sha: pull\.base\.sha/);
+  assert.match(workflow, /head_sha: pull\.head\.sha/);
 });


### PR DESCRIPTION
## Result

Automated ingest pull requests explicitly start the existing rendered-link workflow for their exact base and head revisions. The same change corrects the DCstat redirect regression test so it distinguishes the three migrated `ebpfgo.plugin` routes from the separately published legacy `ebpf.plugin` page.

## Technical reason

Pull requests created with the repository `GITHUB_TOKEN` did not receive a `pull_request` workflow run. The ingest workflow now dispatches the same rendered-link workflow after creating or updating its PR, using the existing token and a shared concurrency identity that prevents duplicate builds.

## Compatibility and risk

- No documentation page, route, redirect catalogue, or deployment behavior changes.
- No new credential is introduced.
- Explicit token permissions preserve the existing content, pull-request, and broken-link issue writes while adding only `actions: write` for workflow dispatch.
- The DCstat assertion validates generated redirect cleanup without changing the catalogue or runtime.

## Validation

- `node --test tests/link_integrity.test.mjs` — 20 passed
- `python ingest/test_legacy_redirect_gate.py` — 27 passed
- `python -m unittest ingest.test_dependency_policy` — 2 passed
- `actionlint -shellcheck= .github/workflows/rendered-link-integrity.yml .github/workflows/ingest.yml` — passed; shellcheck is disabled because the unchanged ingest capture block has pre-existing informational findings
- `git diff --check` — passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs rendered link checks for ingest-created PRs and fixes the DCstat redirect test. Previously, PRs opened by `GITHUB_TOKEN` did not run `pull_request` checks; now the ingest workflow dispatches the rendered-link workflow for the PR’s base and head revisions, with a concurrency key to avoid duplicates.

- `.github/workflows/ingest.yml`: adds `actions: write` permission; after `peter-evans/create-pull-request`, uses `actions/github-script` to call `actions.createWorkflowDispatch` for `rendered-link-integrity.yml` with `pr_number`, `base_sha`, and `head_sha`; rejects external head repos.
- `.github/workflows/rendered-link-integrity.yml`: adds `workflow_dispatch` inputs and threads them through checkout refs and concurrency; `pull_request` and `merge_group` triggers remain.
- `ingest/test_legacy_redirect_gate.py`: updates DCstat checks to target the migrated `ebpfgo.plugin` source and verifies the canonical route is not redirected.
- `tests/link_integrity.test.mjs`: asserts the new dispatch path, inputs, and permissions; actions remain pinned. No content, route, or deploy behavior changes.

<sup>Written for commit 8cd099d8284659ff8b9fea3436f8e388b0026284. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/learn/pull/3043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

