### PR TITLE
fix: make integration alert tables responsive

### DIFF
--- a/src/__mocks__/theme-original/MDXComponents.js
+++ b/src/__mocks__/theme-original/MDXComponents.js
@@ -1,0 +1,3 @@
+export default {
+  a: 'a',
+};

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -572,6 +572,75 @@ html[data-theme='dark'] .sui-layout .sui-result em {
 	@apply prose max-w-none;
 }
 
+.markdown table.integration-alert-table {
+	display: table;
+	table-layout: fixed;
+	width: 100%;
+}
+
+.markdown table.integration-alert-table th:nth-child(1) {
+	width: 25%;
+}
+
+.markdown table.integration-alert-table th:nth-child(2) {
+	width: 30%;
+}
+
+.markdown table.integration-alert-table th:nth-child(3) {
+	width: 45%;
+}
+
+.markdown table.integration-alert-table th:nth-child(-n + 2),
+.markdown table.integration-alert-table td:nth-child(-n + 2) {
+	overflow-wrap: anywhere;
+	word-break: normal;
+}
+
+.markdown table.integration-alert-table td {
+	vertical-align: top;
+}
+
+.integration-alert-table__mobile-label {
+	display: none;
+}
+
+@media (max-width: 640px) {
+	.markdown table.integration-alert-table,
+	.markdown table.integration-alert-table tbody,
+	.markdown table.integration-alert-table tr,
+	.markdown table.integration-alert-table td {
+		display: block;
+		width: 100%;
+	}
+
+	.markdown table.integration-alert-table thead {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		clip-path: inset(50%);
+		white-space: nowrap;
+		border: 0;
+	}
+
+	.markdown table.integration-alert-table tbody tr {
+		margin-bottom: 16px;
+		overflow: hidden;
+		border: 1px solid var(--ifm-table-border-color);
+		border-radius: var(--ifm-global-radius);
+	}
+
+	.markdown .integration-alert-table__mobile-label {
+		display: block;
+		margin-bottom: 4px;
+		color: var(--ifm-font-color-base);
+		font-weight: 700;
+	}
+}
+
 /* Prevent Tailwind prose from adding backtick characters around inline code */
 .markdown code::before,
 .markdown code::after,

--- a/src/theme/MDXComponents/Table/index.js
+++ b/src/theme/MDXComponents/Table/index.js
@@ -1,0 +1,54 @@
+import React from 'react';
+
+const ALERT_TABLE_HEADERS = ['Alert name', 'On metric', 'Description'];
+
+const nodeText = (node) => React.Children.toArray(node)
+  .map((child) => (React.isValidElement(child) ? nodeText(child.props.children) : String(child)))
+  .join('')
+  .trim();
+
+const childrenOfType = (children, type) => React.Children.toArray(children)
+  .filter((child) => React.isValidElement(child) && child.type === type);
+
+const tableHeaders = (children) => {
+  const head = childrenOfType(children, 'thead')[0];
+  const row = head && childrenOfType(head.props.children, 'tr')[0];
+  return row ? childrenOfType(row.props.children, 'th').map((cell) => nodeText(cell.props.children)) : [];
+};
+
+const isAlertTable = (children) => {
+  const headers = tableHeaders(children);
+  return headers.length === ALERT_TABLE_HEADERS.length &&
+    ALERT_TABLE_HEADERS.every((header, index) => headers[index] === header);
+};
+
+const labelBody = (body) => React.cloneElement(body, undefined,
+  React.Children.map(body.props.children, (row) => {
+    if (!React.isValidElement(row) || row.type !== 'tr') return row;
+    return React.cloneElement(row, undefined,
+      React.Children.map(row.props.children, (cell, index) => {
+        if (!React.isValidElement(cell) || cell.type !== 'td' || index >= ALERT_TABLE_HEADERS.length) {
+          return cell;
+        }
+        return React.cloneElement(cell, undefined,
+          <span className="integration-alert-table__mobile-label" aria-hidden="true">
+            {ALERT_TABLE_HEADERS[index]}
+          </span>,
+          cell.props.children,
+        );
+      }),
+    );
+  }),
+);
+
+export default function ResponsiveAlertTable({ children, className, ...props }) {
+  if (!isAlertTable(children)) {
+    return <table className={className} {...props}>{children}</table>;
+  }
+
+  const responsiveChildren = React.Children.map(children, (child) => (
+    React.isValidElement(child) && child.type === 'tbody' ? labelBody(child) : child
+  ));
+  const classes = [className, 'integration-alert-table'].filter(Boolean).join(' ');
+  return <table className={classes} {...props}>{responsiveChildren}</table>;
+}

--- a/src/theme/MDXComponents/Table/index.test.js
+++ b/src/theme/MDXComponents/Table/index.test.js
@@ -1,0 +1,78 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import ResponsiveAlertTable from './index';
+
+const alertTable = (props = {}) => (
+  <ResponsiveAlertTable {...props}>
+    <thead>
+      <tr>
+        <th><span>Alert name</span></th>
+        <th>On metric</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>ceph_health_error</td>
+        <td>prometheus.ceph.cluster.health_status</td>
+        <td>Ceph reports an unhealthy cluster.</td>
+      </tr>
+      <tr>
+        <td>ceph_nvmeof_subsystem_open_security</td>
+        <td>prometheus.ceph.nvme_of.subsystems.state_metadata</td>
+        <td>The subsystem is configured without host security.</td>
+      </tr>
+    </tbody>
+  </ResponsiveAlertTable>
+);
+
+describe('ResponsiveAlertTable', () => {
+  it('labels the exact integration alert schema while preserving table semantics and values', () => {
+    const { container } = render(alertTable({ className: 'existing', 'data-testid': 'alerts' }));
+    const table = screen.getByTestId('alerts');
+    expect(table).toHaveClass('existing', 'integration-alert-table');
+    expect(within(table).getAllByRole('columnheader')).toHaveLength(3);
+    expect(within(table).getAllByRole('row')).toHaveLength(3);
+    const metricCell = within(table).getByText('prometheus.ceph.nvme_of.subsystems.state_metadata').closest('td');
+    expect(metricCell).toHaveAccessibleName('prometheus.ceph.nvme_of.subsystems.state_metadata');
+
+    const labels = container.querySelectorAll('.integration-alert-table__mobile-label');
+    expect(labels).toHaveLength(6);
+    expect(Array.from(labels, (label) => label.textContent)).toEqual([
+      'Alert name', 'On metric', 'Description',
+      'Alert name', 'On metric', 'Description',
+    ]);
+    expect(Array.from(labels).every((label) => label.getAttribute('aria-hidden') === 'true')).toBe(true);
+  });
+
+  it('leaves unrelated and malformed tables unchanged', () => {
+    const { rerender, container } = render(
+      <ResponsiveAlertTable className="ordinary">
+        <thead><tr><th>Name</th><th>Value</th></tr></thead>
+        <tbody><tr><td>one</td><td>1</td></tr></tbody>
+      </ResponsiveAlertTable>,
+    );
+    expect(screen.getByRole('table')).toHaveClass('ordinary');
+    expect(screen.getByRole('table')).not.toHaveClass('integration-alert-table');
+    expect(container.querySelector('.integration-alert-table__mobile-label')).not.toBeInTheDocument();
+
+    rerender(<ResponsiveAlertTable><tbody>plain text</tbody></ResponsiveAlertTable>);
+    expect(screen.getByRole('table')).not.toHaveClass('integration-alert-table');
+  });
+
+  it('keeps non-cell body children and extra cells when enhancing a valid header', () => {
+    const { container } = render(
+      <ResponsiveAlertTable>
+        <thead><tr><th>Alert name</th><th>On metric</th><th>Description</th></tr></thead>
+        <tbody>
+          {'preserved'}
+          <tr><td>alert</td><td>metric</td><td>description</td><td>extra</td></tr>
+        </tbody>
+      </ResponsiveAlertTable>,
+    );
+    expect(screen.getByRole('table')).toHaveClass('integration-alert-table');
+    expect(container.querySelectorAll('.integration-alert-table__mobile-label')).toHaveLength(3);
+    expect(screen.getByText('extra')).toBeInTheDocument();
+    expect(screen.getByText('preserved')).toBeInTheDocument();
+  });
+});

--- a/src/theme/MDXComponents/index.js
+++ b/src/theme/MDXComponents/index.js
@@ -1,0 +1,7 @@
+import OriginalMDXComponents from '@theme-original/MDXComponents';
+import ResponsiveAlertTable from './Table';
+
+export default {
+  ...OriginalMDXComponents,
+  table: ResponsiveAlertTable,
+};

--- a/src/theme/MDXComponents/index.test.js
+++ b/src/theme/MDXComponents/index.test.js
@@ -1,0 +1,10 @@
+import OriginalMDXComponents from '@theme-original/MDXComponents';
+import ResponsiveAlertTable from './Table';
+import MDXComponents from './index';
+
+describe('MDXComponents', () => {
+  it('preserves the original mappings and adds the responsive table renderer', () => {
+    expect(MDXComponents.a).toBe(OriginalMDXComponents.a);
+    expect(MDXComponents.table).toBe(ResponsiveAlertTable);
+  });
+});


### PR DESCRIPTION
## Summary

- add an exact-schema MDX table renderer for integration alert catalogues
- give alert tables fixed 25% / 30% / 45% desktop columns and complete identifier wrapping
- server-render labelled, semantic mobile entries without horizontal overflow
- preserve every existing MDX mapping and leave unrelated tables unchanged

## Validation

- complete required suite: 32 Vitest files / 444 tests, 64 IndexNow tests, 2 Swagger vendor tests, 3 dependency-authority tests, and 4 site-build-gate tests
- changed table renderer: 100% statements, branches, functions, and lines
- Docusaurus production build
- all post-build gates: zero findings across 1,986 HTML files
- required same-site validation: 46,754 checks, zero findings
- all 147 rendered alert pages carry the responsive class and mobile labels
- desktop and mobile headless Chromium geometry and accessibility inspection

The repository-wide coverage command remains red because its existing V8 remapper cannot parse several JSX-in-.js theme files and unrelated existing files are below the configured global threshold; the changed renderer itself is fully covered.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes integration alert tables responsive and accessible. Old behavior: alert tables overflowed on mobile and long identifiers broke layouts. New behavior: fixed desktop column widths with safe wrapping, and labeled, overflow-free rows on small screens. Only alert tables with the exact header trio are affected; other tables render unchanged.

- Review notes
  - Replaces the MDX `table` mapping with `ResponsiveAlertTable` via `@theme-original/MDXComponents`, preserving all other mappings.
  - Enhances only tables whose headers exactly match: Alert name, On metric, Description; unrelated or malformed tables are untouched.
  - Adds the `integration-alert-table` and `integration-alert-table__mobile-label` classes; keeps table semantics and accessible names while hiding thead visually on mobile.
  - CSS applies fixed desktop widths (25%/30%/45%) and a block layout on small screens to remove horizontal overflow.

- Author guidance
  - To opt in, write headers exactly as: Alert name | On metric | Description, in that order.
  - No other author or build changes are required.

<sup>Written for commit 003c169b11f6ee369a01c0f284e73ff8551bd554. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/learn/pull/3045?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added responsive formatting for integration alert tables.
  * Tables display clearly on desktop and transform into labeled, card-style layouts on mobile.
  * Existing table formatting remains unchanged for unrelated tables.

* **Tests**
  * Added coverage for responsive layouts, accessibility labels, table variations, and component mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->