### PR TITLE
Add search to Prometheus profile metric catalogues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,3 +46,12 @@ Netlify build or deployment responsible for merge eligibility:
 - Generated documentation must be repaired through its owning producer and normal ingestion path;
   do not hand-edit output that regeneration will replace.
 - Use explicit file paths when staging changes; never stage the whole worktree.
+
+## Generated Prometheus profile catalogues
+
+Agent-generated Prometheus profile catalogues carry static `data-prometheus-profile-catalog`,
+`data-prometheus-profile`, `data-prometheus-profile-family`, and
+`data-prometheus-profile-chart` hooks. The Learn theme root enhances those disclosures with
+catalogue-scoped search, counts, and expand/collapse controls after initial render and client-side
+navigation. Keep all catalogue content in the generated HTML for no-JavaScript use; Learn must not
+parse Agent profile source contracts or hand-edit generated integration pages.

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -604,7 +604,95 @@ html[data-theme='dark'] .sui-layout .sui-result em {
 	display: none;
 }
 
+.markdown [data-prometheus-profile-catalog] [hidden] {
+	display: none !important;
+}
+
+.markdown [data-prometheus-profile-catalog] code {
+	overflow-wrap: anywhere;
+	word-break: break-word;
+}
+
+.prometheus-profile-tools {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto;
+	gap: 0.75rem 1rem;
+	padding: 1rem;
+	border-bottom: 1px solid var(--ifm-color-emphasis-300);
+	background: var(--ifm-color-emphasis-100);
+}
+
+.prometheus-profile-search-field {
+	display: grid;
+	gap: 0.375rem;
+}
+
+.prometheus-profile-search-field label {
+	font-size: 0.875rem;
+	font-weight: 700;
+}
+
+.prometheus-profile-search-field input {
+	width: 100%;
+	min-width: 0;
+	padding: 0.625rem 0.75rem;
+	border: 1px solid var(--ifm-color-emphasis-300);
+	border-radius: var(--ifm-global-radius);
+	color: var(--ifm-font-color-base);
+	background: var(--ifm-background-color);
+}
+
+.prometheus-profile-search-field input:focus {
+	border-color: var(--ifm-color-primary);
+	outline: 2px solid var(--ifm-color-primary);
+	outline-offset: 2px;
+}
+
+.prometheus-profile-actions {
+	display: flex;
+	align-items: end;
+	gap: 0.5rem;
+}
+
+.prometheus-profile-actions button {
+	min-height: 42px;
+	padding: 0.5rem 0.75rem;
+	border: 1px solid var(--ifm-color-emphasis-300);
+	border-radius: var(--ifm-global-radius);
+	color: var(--ifm-font-color-base);
+	background: var(--ifm-background-color);
+	cursor: pointer;
+}
+
+.prometheus-profile-actions button:hover,
+.prometheus-profile-actions button:focus-visible {
+	border-color: var(--ifm-color-primary);
+}
+
+.prometheus-profile-search-status {
+	grid-column: 1 / -1;
+	min-height: 1.25rem;
+	margin: 0;
+	font-size: 0.875rem;
+}
+
+.prometheus-profile-search-status.is-empty {
+	font-weight: 700;
+}
+
 @media (max-width: 640px) {
+	.prometheus-profile-tools {
+		grid-template-columns: minmax(0, 1fr);
+	}
+
+	.prometheus-profile-actions {
+		align-items: stretch;
+	}
+
+	.prometheus-profile-actions button {
+		flex: 1;
+	}
+
 	.markdown table.integration-alert-table,
 	.markdown table.integration-alert-table tbody,
 	.markdown table.integration-alert-table tr,

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -610,7 +610,6 @@ html[data-theme='dark'] .sui-layout .sui-result em {
 
 .markdown [data-prometheus-profile-catalog] code {
 	overflow-wrap: anywhere;
-	word-break: break-word;
 }
 
 .prometheus-profile-tools {

--- a/src/theme/PrometheusProfileCatalog/index.js
+++ b/src/theme/PrometheusProfileCatalog/index.js
@@ -1,0 +1,135 @@
+const CATALOG_SELECTOR = '[data-prometheus-profile-catalog]';
+const PROFILE_SELECTOR = '[data-prometheus-profile]';
+const FAMILY_SELECTOR = '[data-prometheus-profile-family]';
+const CHART_SELECTOR = '[data-prometheus-profile-chart]';
+
+const normalize = (value) => value
+  .normalize('NFKD')
+  .replace(/[\u0300-\u036f]/g, '')
+  .toLowerCase()
+  .trim();
+
+const createControls = (inputId) => {
+  const controls = document.createElement('div');
+  controls.className = 'prometheus-profile-tools';
+
+  const field = document.createElement('div');
+  field.className = 'prometheus-profile-search-field';
+  const label = document.createElement('label');
+  label.htmlFor = inputId;
+  label.textContent = 'Search curated charts';
+  const input = document.createElement('input');
+  input.id = inputId;
+  input.type = 'search';
+  input.autocomplete = 'off';
+  input.placeholder = 'Search charts, metrics, dimensions…';
+  field.append(label, input);
+
+  const actions = document.createElement('div');
+  actions.className = 'prometheus-profile-actions';
+  const expand = document.createElement('button');
+  expand.type = 'button';
+  expand.textContent = 'Expand all';
+  const collapse = document.createElement('button');
+  collapse.type = 'button';
+  collapse.textContent = 'Collapse all';
+  actions.append(expand, collapse);
+
+  const status = document.createElement('p');
+  status.className = 'prometheus-profile-search-status';
+  status.setAttribute('role', 'status');
+  status.setAttribute('aria-live', 'polite');
+  status.setAttribute('aria-atomic', 'true');
+  controls.append(field, actions, status);
+  return { controls, input, expand, collapse, status };
+};
+
+export const enhancePrometheusProfileCatalogs = (root = document) => {
+  root.querySelectorAll(CATALOG_SELECTOR).forEach((catalog, index) => {
+    if (catalog.dataset.prometheusProfileCatalogEnhanced === 'true') return;
+
+    const summary = catalog.querySelector(':scope > summary');
+    const charts = Array.from(catalog.querySelectorAll(CHART_SELECTOR));
+    if (!summary || charts.length === 0) return;
+
+    const disclosures = Array.from(catalog.querySelectorAll('details'));
+    const initialOpen = new Map(disclosures.map((details) => [details, details.open]));
+    const profiles = Array.from(catalog.querySelectorAll(PROFILE_SELECTOR));
+    const families = Array.from(catalog.querySelectorAll(FAMILY_SELECTOR));
+    const searchable = new Map(charts.map((chart) => [chart, normalize(chart.textContent)]));
+    const inputId = `prometheus-profile-search-${index + 1}`;
+    const { controls, input, expand, collapse, status } = createControls(inputId);
+
+    summary.insertAdjacentElement('afterend', controls);
+    catalog.dataset.prometheusProfileCatalogEnhanced = 'true';
+
+    const setStatus = (query, visibleCount) => {
+      status.classList.toggle('is-empty', Boolean(query) && visibleCount === 0);
+      if (!query) {
+        status.textContent = `${charts.length} ${charts.length === 1 ? 'chart' : 'charts'}`;
+      } else if (visibleCount === 0) {
+        status.textContent = `No charts match “${input.value.trim()}”.`;
+      } else {
+        status.textContent = `${visibleCount} of ${charts.length} charts shown`;
+      }
+    };
+
+    const restore = () => {
+      charts.forEach((chart) => { chart.hidden = false; });
+      families.forEach((family) => { family.hidden = false; });
+      profiles.forEach((profile) => { profile.hidden = false; });
+      disclosures.forEach((details) => { details.open = initialOpen.get(details); });
+      setStatus('', charts.length);
+    };
+
+    const update = () => {
+      const query = normalize(input.value);
+      if (!query) {
+        restore();
+        return;
+      }
+
+      let visibleCount = 0;
+      const visibleFamilies = new Set();
+      const visibleProfiles = new Set();
+      charts.forEach((chart) => {
+        const visible = searchable.get(chart).includes(query);
+        chart.hidden = !visible;
+        chart.open = visible;
+        chart.querySelectorAll('details').forEach((details) => { details.open = visible; });
+        if (!visible) return;
+
+        visibleCount += 1;
+        let ancestor = chart.parentElement;
+        while (ancestor && ancestor !== catalog) {
+          if (ancestor.matches(FAMILY_SELECTOR)) visibleFamilies.add(ancestor);
+          if (ancestor.matches(PROFILE_SELECTOR)) visibleProfiles.add(ancestor);
+          ancestor = ancestor.parentElement;
+        }
+      });
+
+      families.forEach((family) => {
+        const hasVisibleChart = visibleFamilies.has(family);
+        family.hidden = !hasVisibleChart;
+        family.open = hasVisibleChart;
+      });
+      profiles.forEach((profile) => {
+        const hasVisibleChart = visibleProfiles.has(profile);
+        profile.hidden = !hasVisibleChart;
+        profile.open = hasVisibleChart;
+      });
+      setStatus(query, visibleCount);
+    };
+
+    const setVisibleDisclosures = (open) => {
+      disclosures.forEach((details) => {
+        if (!details.hidden && !details.closest('details[hidden]')) details.open = open;
+      });
+    };
+
+    input.addEventListener('input', update);
+    expand.addEventListener('click', () => setVisibleDisclosures(true));
+    collapse.addEventListener('click', () => setVisibleDisclosures(false));
+    setStatus('', charts.length);
+  });
+};

--- a/src/theme/PrometheusProfileCatalog/index.test.js
+++ b/src/theme/PrometheusProfileCatalog/index.test.js
@@ -1,0 +1,99 @@
+import { fireEvent, getByLabelText, getByRole, queryAllByLabelText } from '@testing-library/dom';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { enhancePrometheusProfileCatalogs } from './index';
+
+const catalogue = (suffix = 'one', chartCount = 3) => `
+  <details open data-prometheus-profile-catalog id="catalogue-${suffix}">
+    <summary>Curated profile coverage</summary>
+    <details open data-prometheus-profile>
+      <summary>Ceph profile</summary>
+      <details data-prometheus-profile-family>
+        <summary>Health</summary>
+        <details data-prometheus-profile-chart id="health-${suffix}">
+          <summary>Cluster Health</summary>
+          <p>Dimensions: healthy, warning, critical</p>
+          <details><summary>Source selectors</summary><code>ceph_health_status</code></details>
+        </details>
+        ${chartCount > 1 ? `<details data-prometheus-profile-chart id="latency-${suffix}">
+          <summary>Request Duration</summary>
+          <p>Operator question: How is request latency distributed?</p>
+          <details>
+            <summary>Source selectors</summary>
+            <code>prometheus.ceph.request_duration_seconds_bucket</code>
+          </details>
+        </details>` : ''}
+      </details>
+      ${chartCount > 2 ? `<details data-prometheus-profile-family>
+        <summary>Capacity</summary>
+        <details data-prometheus-profile-chart id="capacity-${suffix}">
+          <summary>Cluster Capacity</summary><p>Units: bytes</p>
+        </details>
+      </details>` : ''}
+    </details>
+  </details>`;
+
+describe('Prometheus profile catalogue enhancement', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('ignores incomplete and empty catalogues', () => {
+    document.body.innerHTML = `
+      <details data-prometheus-profile-catalog><p>No summary</p></details>
+      <details data-prometheus-profile-catalog><summary>No charts</summary></details>`;
+
+    enhancePrometheusProfileCatalogs();
+
+    expect(queryAllByLabelText(document.body, 'Search curated charts')).toHaveLength(0);
+  });
+
+  it('searches normalized chart content, reports no results, and restores authored state', () => {
+    document.body.innerHTML = catalogue();
+    enhancePrometheusProfileCatalogs();
+    const catalog = document.querySelector('#catalogue-one');
+    const input = getByLabelText(catalog, 'Search curated charts');
+    const status = getByRole(catalog, 'status');
+
+    expect(status).toHaveTextContent('3 charts');
+    fireEvent.input(input, { target: { value: 'Dúration' } });
+    expect(status).toHaveTextContent('1 of 3 charts shown');
+    expect(document.querySelector('#latency-one')).not.toHaveAttribute('hidden');
+    expect(document.querySelector('#latency-one')).toHaveAttribute('open');
+    expect(document.querySelector('#latency-one details')).toHaveAttribute('open');
+    expect(document.querySelector('#health-one')).toHaveAttribute('hidden');
+    expect(document.querySelector('#capacity-one')).toHaveAttribute('hidden');
+    fireEvent.click(getByRole(catalog, 'button', { name: 'Expand all' }));
+    expect(document.querySelector('#latency-one details')).toHaveAttribute('open');
+
+    fireEvent.input(input, { target: { value: 'does not exist' } });
+    expect(status).toHaveTextContent('No charts match “does not exist”.');
+    expect(status).toHaveClass('is-empty');
+    expect(catalog.querySelector('[data-prometheus-profile]')).toHaveAttribute('hidden');
+
+    fireEvent.input(input, { target: { value: '' } });
+    expect(status).toHaveTextContent('3 charts');
+    expect(status).not.toHaveClass('is-empty');
+    expect(catalog.querySelector('[data-prometheus-profile]')).toHaveAttribute('open');
+    expect(catalog.querySelector('[data-prometheus-profile-family]')).not.toHaveAttribute('open');
+    expect(document.querySelector('#health-one')).not.toHaveAttribute('hidden');
+  });
+
+  it('uses native controls, isolates catalogues, and initializes only once', () => {
+    document.body.innerHTML = `${catalogue()}${catalogue('two', 1)}`;
+    enhancePrometheusProfileCatalogs();
+    enhancePrometheusProfileCatalogs();
+    const first = document.querySelector('#catalogue-one');
+    const second = document.querySelector('#catalogue-two');
+
+    expect(queryAllByLabelText(document.body, 'Search curated charts')).toHaveLength(2);
+    expect(getByRole(second, 'status')).toHaveTextContent('1 chart');
+    fireEvent.click(getByRole(first, 'button', { name: 'Expand all' }));
+    expect(Array.from(first.querySelectorAll('details')).every((details) => details.open)).toBe(true);
+    expect(second.querySelector('[data-prometheus-profile-family]')).not.toHaveAttribute('open');
+
+    fireEvent.click(getByRole(first, 'button', { name: 'Collapse all' }));
+    expect(Array.from(first.querySelectorAll('details')).every((details) => !details.open)).toBe(true);
+    expect(first).toHaveAttribute('open');
+  });
+});

--- a/src/theme/Root/index.js
+++ b/src/theme/Root/index.js
@@ -1,8 +1,9 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Head from '@docusaurus/Head';
 import { useLocation } from '@docusaurus/router';
 
 import { NEDI_HEAD_TAGS, documentPathname, isNediRoute } from '@site/src/components/Nedi/assets';
+import { enhancePrometheusProfileCatalogs } from '@site/src/theme/PrometheusProfileCatalog';
 
 // The Ask Nedi route is the only page that uses the embed, so its stylesheet and
 // scripts are declared here rather than in the site-wide head. Rendering them on the
@@ -23,6 +24,10 @@ export default function Root({ children }) {
   // Root is mounted once per document, so this stays the pathname the document was
   // rendered for even after client-side navigation.
   const [renderedPathname] = useState(() => documentPathname(pathname));
+
+  useEffect(() => {
+    enhancePrometheusProfileCatalogs();
+  }, [pathname]);
 
   return (
     <>


### PR DESCRIPTION
## Summary

- enhance Agent-generated Prometheus profile catalogues with labelled local search, live chart counts, no-results feedback, and native expand/collapse controls
- rerun enhancement after Docusaurus client-side navigation while keeping initialization idempotent
- preserve all generated catalogue content for no-JavaScript use
- document Learn ownership of presentation and Agent ownership of generated semantics

## Dependency and merge order

This consumes the static catalogue hooks produced by netdata/netdata#23607. It is safe to merge before the Agent PR: current integration pages have no matching hooks, so the enhancement is a no-op until the normal ingestion update lands.

## Validation

- focused catalogue and Root tests: 10 passed
- catalogue module coverage: 100% statements, branches, functions, and lines
- full test command: 447 Vitest tests plus IndexNow, Swagger UI, dependency-authority, and site-build-gate suites passed
- Docusaurus production build: completed
- post-build gates: 1,980 sitemap titles, 822,347 internal links, zero noindex findings, and static site gate passed
- exact 569-chart Ceph payload: 10 ms initialization, one-result metric search, no 350 px overflow
- React rerender lifecycle reproducer and final adversarial review: passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds in-page search, native expand/collapse, and result counts to Prometheus profile catalogues while preserving no-JavaScript content. Catalogues were static; they now filter charts live with no-results feedback and remove a deprecated catalogue wrapping rule.

- Activates only on catalogues exposing `data-prometheus-profile-catalog`, `data-prometheus-profile`, `data-prometheus-profile-family`, and `data-prometheus-profile-chart`. Safe to merge now; current pages lack these hooks, so this is a no-op until the Agent ships them.
- Initializes after render and on client-side navigation from `Root` (idempotent per catalogue). Uses `hidden` for filtering and restores authored disclosure state when the search clears.
- Adds scoped CSS for the search UI and long-token handling; removes a deprecated wrapping rule. Migration: Agent must emit the static hooks; documentation authors must not hand-edit generated integration pages.

<sup>Written for commit fb707d22361f2847d4b1fb56f3d1034307696930. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/learn/pull/3046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added search and match counts for Prometheus profile catalogues.
  - Added expand/collapse controls for catalogue sections.
  - Enhancements remain available after page navigation and work without JavaScript.

- **Style**
  - Added responsive layouts, themed controls, focus states, and improved handling for long catalogue content.

- **Bug Fixes**
  - Improved empty-search behavior and restored sections to their original disclosure states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->