### PR TITLE
Apply the integration page-weight policy to Learn

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,16 @@ Netlify build or deployment responsible for merge eligibility:
   do not hand-edit output that regeneration will replace.
 - Use explicit file paths when staging changes; never stage the whole worktree.
 
+## Static build gate contract
+
+- Learn commits the complete checksum-bound Node.js 22 gate under `scripts/site-build-gate/` and
+  runs it locally after Docusaurus. CI and deployment do not fetch or execute the SEO repository.
+- Learn declares `/docs/collecting-metrics/collectors` as its segment-safe integration route
+  prefix. The generic page-weight diagnostic excludes that route family; integration pages remain
+  subject to every non-weight rule, so this is not a whole-page validation bypass.
+- `config/site-build-gate-baseline.json` contains only exact, reasoned current findings. Never add
+  or widen an entry to make a build pass without an explicit policy decision.
+
 ## Generated Prometheus profile catalogues
 
 Agent-generated Prometheus profile catalogues carry static `data-prometheus-profile-catalog`,

--- a/config/site-build-gate-baseline.json
+++ b/config/site-build-gate-baseline.json
@@ -1,6 +1,6 @@
 {
   "schema": "netdata-site-build-gate-baseline-v1",
   "contract": "netdata-site-build-gate-v1",
-  "ruleset_version": 9,
+  "ruleset_version": 10,
   "allowed": []
 }

--- a/scripts/run-post-build-gates.mjs
+++ b/scripts/run-post-build-gates.mjs
@@ -28,6 +28,8 @@ const strictGeneratedCorpusGates = [
     'https://learn.netdata.cloud',
     '--baseline',
     'config/site-build-gate-baseline.json',
+    '--integration-route-prefix',
+    '/docs/collecting-metrics/collectors',
     '--format',
     'json',
   ],

--- a/scripts/site-build-gate/manifest.json
+++ b/scripts/site-build-gate/manifest.json
@@ -1,20 +1,20 @@
 {
   "schema": "netdata-site-build-gate-vendor-v2",
   "contract": "netdata-site-build-gate-v1",
-  "ruleset_version": 9,
+  "ruleset_version": 10,
   "node_major": 22,
   "artifacts": [
     {
       "path": "package-lock.json",
-      "sha256": "fc4401552f006f521fb61684c533fe97747a8a8dcba73abdfa4ab9d3f3a43ef0"
+      "sha256": "2f474bd510cf012a3601d439268c19f25e8f42e6d643598563f65e411fe244f9"
     },
     {
       "path": "package.json",
-      "sha256": "fcf96b638f7a47e5f7d0e23a893af49c5b1ea1526b9335afa6d07fc80e976839"
+      "sha256": "5cd23bae2605a5fcd2bed67b547ae7a4be0f9102dde6265eb4a770c59dce9fe4"
     },
     {
       "path": "site_build_gate.mjs",
-      "sha256": "182c683910ec565e007f0d5d5f5fee5ec3050bf6b592e3885bdc1e4972de9fd8"
+      "sha256": "171cc249076efa1e9e1edb5cecdbd83b5487f9ea6c7e5b94caa73a1be2f44d4f"
     }
   ]
 }

--- a/scripts/site-build-gate/package-lock.json
+++ b/scripts/site-build-gate/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@netdata/site-build-gate",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@netdata/site-build-gate",
-      "version": "9.0.0",
+      "version": "10.0.0",
       "dependencies": {
         "css-tree": "3.2.1",
         "parse5": "8.0.1",

--- a/scripts/site-build-gate/package.json
+++ b/scripts/site-build-gate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netdata/site-build-gate",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/scripts/site-build-gate/site_build_gate.mjs
+++ b/scripts/site-build-gate/site_build_gate.mjs
@@ -21,7 +21,7 @@ export const CONTRACT_SCHEMA = "netdata-site-build-gate-v1";
 export const MANIFEST_SCHEMA = "netdata-site-build-gate-vendor-v2";
 export const BASELINE_SCHEMA = "netdata-site-build-gate-baseline-v1";
 export const REPORT_SCHEMA = "netdata-site-build-gate-report-v1";
-export const RULESET_VERSION = 9;
+export const RULESET_VERSION = 10;
 export const REQUIRED_NODE_MAJOR = 22;
 export const HEAVY_BYTES = 500_000;
 
@@ -231,6 +231,25 @@ export function normalizeSiteOrigin(value) {
     throw new GateError(`site origin must not contain a path, query, or fragment: ${JSON.stringify(value)}`);
   }
   return parsed.origin;
+}
+
+export function normalizeIntegrationRoutePrefixes(values = []) {
+  if (!Array.isArray(values)) throw new GateError("integration route prefixes must be a list");
+  const policyOrigin = "https://integration-policy.invalid";
+  const normalized = values.map((value) => {
+    if (typeof value !== "string" || !value.startsWith("/")) {
+      throw new GateError(`integration route prefix must be an absolute path: ${JSON.stringify(value)}`);
+    }
+    const parsed = checkedUrl(`${policyOrigin}${value}`, policyOrigin, "integration route prefix");
+    const decoded = safeUrlPath(parsed, "integration route prefix").decodedPath;
+    const prefix = decoded.length > 1 && decoded.endsWith("/") ? decoded.slice(0, -1) : decoded;
+    if (prefix === "/") throw new GateError("integration route prefix cannot cover the site root");
+    return prefix;
+  }).sort(compareText);
+  if (new Set(normalized).size !== normalized.length) {
+    throw new GateError("integration route prefixes must be unique after normalization");
+  }
+  return normalized;
 }
 
 function safeUrlPath(parsed, label) {
@@ -891,11 +910,18 @@ function sortedFindings(findings) {
   return findings.sort((a, b) => compareText(a.rule, b.rule) || compareText(a.path, b.path) || compareText(a.identity, b.identity));
 }
 
-export function scanBuiltHtml(buildDir, siteOrigin) {
+function isIntegrationPolicyPath(policyPath, integrationRoutePrefixes) {
+  return integrationRoutePrefixes.some((prefix) =>
+    policyPath === prefix || policyPath.startsWith(`${prefix}/`),
+  );
+}
+
+export function scanBuiltHtml(buildDir, siteOrigin, { integrationRoutePrefixes = [] } = {}) {
   const rootInput = resolve(buildDir);
   if (!existsSync(rootInput) || !statSync(rootInput).isDirectory()) throw new GateError(`build directory does not exist: ${buildDir}`);
   const root = realpathSync(rootInput);
   const origin = typeof siteOrigin === "string" ? normalizeSiteOrigin(siteOrigin) : siteOrigin;
+  const integrationPrefixes = normalizeIntegrationRoutePrefixes(integrationRoutePrefixes);
   const sitemapRoutes = new Map();
   const sitemapArtifacts = new Map();
   for (const location of sitemapUrls(root, origin)) {
@@ -933,7 +959,7 @@ export function scanBuiltHtml(buildDir, siteOrigin) {
     if (page.images_without_alt) {
       findings.push(finding("images-missing-alt", page.route, `${page.images_without_alt} statically exposed HTML image(s) lack an alt attribute`, stateSignature({ count: page.images_without_alt })));
     }
-    if (page.html_bytes > HEAVY_BYTES) {
+    if (page.html_bytes > HEAVY_BYTES && !isIntegrationPolicyPath(page.policy_path, integrationPrefixes)) {
       findings.push(finding("heavy-page", page.route, `${page.html_bytes} bytes exceeds the ${HEAVY_BYTES}-byte estate guardrail`, stateSignature({
         bytes_without_site_origin: page.html_bytes_without_site_origin,
         site_origin_occurrences: page.site_origin_occurrences,
@@ -965,7 +991,11 @@ export function scanBuiltHtml(buildDir, siteOrigin) {
       for (const page of group) findings.push(finding(rule, page.route, `value is shared by ${group.length} pages`, signature));
     }
   }
-  return { pages: pages.sort((a, b) => compareText(a.route, b.route)), findings: sortedFindings(findings) };
+  return {
+    pages: pages.sort((a, b) => compareText(a.route, b.route)),
+    findings: sortedFindings(findings),
+    integrationRoutePrefixes: integrationPrefixes,
+  };
 }
 
 export function loadBaseline(path) {
@@ -988,10 +1018,11 @@ export function loadBaseline(path) {
   return allowed;
 }
 
-export function runGate(buildDir, { siteOrigin, baselinePath = null }) {
+export function runGate(buildDir, { siteOrigin, baselinePath = null, integrationRoutePrefixes = [] }) {
   requireNode22();
   const origin = normalizeSiteOrigin(siteOrigin);
-  const { pages, findings } = scanBuiltHtml(buildDir, origin);
+  const { pages, findings, integrationRoutePrefixes: normalizedIntegrationPrefixes } =
+    scanBuiltHtml(buildDir, origin, { integrationRoutePrefixes });
   const allowed = loadBaseline(baselinePath);
   const identities = new Set(findings.map((item) => item.identity));
   const regressions = findings.filter((item) => !allowed.has(item.identity));
@@ -1004,6 +1035,7 @@ export function runGate(buildDir, { siteOrigin, baselinePath = null }) {
     contract: CONTRACT_SCHEMA,
     ruleset_version: RULESET_VERSION,
     site_origin: origin,
+    integration_route_prefixes: normalizedIntegrationPrefixes,
     checked_pages: pages.length,
     checked_index_pages: pages.filter((page) => page.in_sitemap && !page.noindex).length,
     counts: Object.fromEntries(Object.entries(counts).sort(([a], [b]) => compareText(a, b))),
@@ -1022,16 +1054,17 @@ function printText(report) {
 }
 
 function parseArgs(argv) {
-  const args = { buildDir: null, siteOrigin: null, baseline: null, manifest: join(dirname(fileURLToPath(import.meta.url)), "manifest.json"), format: "text" };
+  const args = { buildDir: null, siteOrigin: null, baseline: null, manifest: join(dirname(fileURLToPath(import.meta.url)), "manifest.json"), format: "text", integrationRoutePrefixes: [] };
   for (let index = 0; index < argv.length; index += 2) {
     const name = argv[index];
     const value = argv[index + 1];
-    if (!value || !new Set(["--build-dir", "--site-origin", "--baseline", "--manifest", "--format"]).has(name)) throw new GateError(`invalid or incomplete argument: ${name || "<missing>"}`);
+    if (!value || !new Set(["--build-dir", "--site-origin", "--baseline", "--manifest", "--format", "--integration-route-prefix"]).has(name)) throw new GateError(`invalid or incomplete argument: ${name || "<missing>"}`);
     if (name === "--build-dir") args.buildDir = value;
     else if (name === "--site-origin") args.siteOrigin = value;
     else if (name === "--baseline") args.baseline = value;
     else if (name === "--manifest") args.manifest = value;
-    else args.format = value;
+    else if (name === "--format") args.format = value;
+    else args.integrationRoutePrefixes.push(value);
   }
   if (!args.buildDir || !args.siteOrigin) throw new GateError("--build-dir and --site-origin are required");
   if (!new Set(["text", "json"]).has(args.format)) throw new GateError("--format must be text or json");
@@ -1043,7 +1076,11 @@ export function main(argv = process.argv.slice(2)) {
     const args = parseArgs(argv);
     const artifact = fileURLToPath(import.meta.url);
     verifyContract(artifact, resolve(args.manifest));
-    const report = runGate(args.buildDir, { siteOrigin: args.siteOrigin, baselinePath: args.baseline });
+    const report = runGate(args.buildDir, {
+      siteOrigin: args.siteOrigin,
+      baselinePath: args.baseline,
+      integrationRoutePrefixes: args.integrationRoutePrefixes,
+    });
     if (args.format === "json") console.log(JSON.stringify(report, null, 2));
     else printText(report);
     return report.regressions.length ? 1 : 0;

--- a/src/seo/deploymentIntegrations.test.js
+++ b/src/seo/deploymentIntegrations.test.js
@@ -28,6 +28,8 @@ describe('shared deployment integrations', () => {
       'https://learn.netdata.cloud',
       '--baseline',
       'config/site-build-gate-baseline.json',
+      '--integration-route-prefix',
+      '/docs/collecting-metrics/collectors',
       '--format',
       'json',
     ]);
@@ -44,7 +46,7 @@ describe('shared deployment integrations', () => {
     expect(manifest).toMatchObject({
       schema: 'netdata-site-build-gate-vendor-v2',
       contract: 'netdata-site-build-gate-v1',
-      ruleset_version: 9,
+      ruleset_version: 10,
       node_major: 22,
     });
   });

--- a/src/seo/postBuildGates.test.js
+++ b/src/seo/postBuildGates.test.js
@@ -39,6 +39,8 @@ describe('post-build gate rollout', () => {
         'https://learn.netdata.cloud',
         '--baseline',
         'config/site-build-gate-baseline.json',
+        '--integration-route-prefix',
+        '/docs/collecting-metrics/collectors',
         '--format',
         'json',
       ],

--- a/tests/site_build_gate.test.js
+++ b/tests/site_build_gate.test.js
@@ -13,20 +13,20 @@ const gate = path.join(vendor, 'site_build_gate.mjs');
 const expectedManifest = {
   schema: 'netdata-site-build-gate-vendor-v2',
   contract: 'netdata-site-build-gate-v1',
-  ruleset_version: 9,
+  ruleset_version: 10,
   node_major: 22,
   artifacts: [
     {
       path: 'package-lock.json',
-      sha256: 'fc4401552f006f521fb61684c533fe97747a8a8dcba73abdfa4ab9d3f3a43ef0',
+      sha256: '2f474bd510cf012a3601d439268c19f25e8f42e6d643598563f65e411fe244f9',
     },
     {
       path: 'package.json',
-      sha256: 'fcf96b638f7a47e5f7d0e23a893af49c5b1ea1526b9335afa6d07fc80e976839',
+      sha256: '5cd23bae2605a5fcd2bed67b547ae7a4be0f9102dde6265eb4a770c59dce9fe4',
     },
     {
       path: 'site_build_gate.mjs',
-      sha256: '182c683910ec565e007f0d5d5f5fee5ec3050bf6b592e3885bdc1e4972de9fd8',
+      sha256: '171cc249076efa1e9e1edb5cecdbd83b5487f9ea6c7e5b94caa73a1be2f44d4f',
     },
   ],
 };
@@ -40,7 +40,7 @@ function writeFixture(directory, sitemap, html) {
   fs.writeFileSync(path.join(directory, 'index.html'), html);
 }
 
-test('the site vendors the exact accepted ruleset-v9 bundle', () => {
+test('the site vendors the exact accepted ruleset-v10 bundle', () => {
   const manifest = JSON.parse(fs.readFileSync(path.join(vendor, 'manifest.json'), 'utf8'));
   assert.deepEqual(manifest, expectedManifest);
   for (const artifact of manifest.artifacts) {
@@ -63,6 +63,7 @@ test('every Netlify context stages the clean-installed gate after Docusaurus', a
     '--build-dir', 'build',
     '--site-origin', 'https://learn.netdata.cloud',
     '--baseline', 'config/site-build-gate-baseline.json',
+    '--integration-route-prefix', '/docs/collecting-metrics/collectors',
     '--format', 'json',
   ]);
   assert.match(command, new RegExp(install));


### PR DESCRIPTION
## Result

- Vendors checksum-bound site gate ruleset 10.
- Declares `/docs/collecting-metrics/collectors` as the Learn integration route family.
- Skips only the generic `heavy-page` diagnostic for generated collector references.
- Keeps every other Learn post-build gate active.

## Reason

Ingest PR #3047 builds successfully, then fails because the complete Ceph Prometheus metric and alert reference is 727,790 bytes. That size is expected operator-facing catalogue coverage, not a broken Learn page.

## Compatibility

All non-integration routes retain the 500,000-byte guardrail. Integration pages remain subject to title, description, heading, image-alt, duplicate, link, redirect, indexability, and analytics checks. Learn remains self-contained and executes its committed gate copy without an SEO checkout.

## Validation

- exact Netlify build command passes
- 447 tests pass
- site gate: 1,986 HTML pages, 0 findings
- exact PR #3047 rendered output scanned separately: 1,987 pages, 0 findings
- exact canonical vendor verification

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies the integration page-weight policy to Learn by vendoring gate ruleset v10 and skipping the heavy-page diagnostic for generated collector references. Previously, all pages were subject to the 500,000‑byte guardrail; now only routes under /docs/collecting-metrics/collectors are exempt from that single check, while all other checks remain.

- CI runs the vendored Node.js 22 gate (`ruleset_version: 10`) and passes `--integration-route-prefix /docs/collecting-metrics/collectors`; the report now includes `integration_route_prefixes`.
- Only the heavy-page rule is skipped for that route family; title, description, heading, image-alt, duplicate, link, redirect, indexability, and analytics gates remain active.
- Non-integration routes keep the 500,000‑byte limit; Learn continues to execute its committed gate without a separate SEO checkout.
- Migration: when adding new integration route families, add their prefixes to the run script and tests.

<sup>Written for commit fe39c60ad263a580a453589455f4c3fc3d3b634e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/learn/pull/3048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Site build validation now recognizes designated integration routes, reducing misleading heavy-page diagnostics for those pages.
  * Build reports include normalized integration route details for clearer validation results.
  * Updated the build validation ruleset and baseline to the latest version.

* **Tests**
  * Updated automated checks to verify integration route handling and the refreshed build validation ruleset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->