### PR TITLE
Add explicit Ask Nedi page description

### DIFF
--- a/docs/ask-nedi.mdx
+++ b/docs/ask-nedi.mdx
@@ -1,6 +1,7 @@
 ---
 id: ask-nedi
 title: " "
+description: "Ask Nedi, Netdata's AI assistant, questions about Netdata documentation, configuration, monitoring, and troubleshooting."
 sidebar_label: "Ask Nedi"
 sidebar_position: "0"
 hide_title: true

--- a/docs/ask-nedi.mdx
+++ b/docs/ask-nedi.mdx
@@ -1,7 +1,6 @@
 ---
 id: ask-nedi
 title: " "
-description: "Ask Nedi, Netdata's AI assistant, questions about Netdata documentation, configuration, monitoring, and troubleshooting."
 sidebar_label: "Ask Nedi"
 sidebar_position: "0"
 hide_title: true

--- a/src/seo/askNediMetadata.test.js
+++ b/src/seo/askNediMetadata.test.js
@@ -4,12 +4,11 @@ import process from 'node:process';
 import {parse} from 'parse5';
 import {describe, expect, it} from 'vitest';
 
-import {
-  ASK_NEDI_DESCRIPTION,
-  resolveDocDescription,
-} from './description';
+import {resolveDocDescription} from './description';
 
 const buildRoot = process.env.BUILT_SITE_DIR;
+const expectedAskNediDescription =
+  "Ask Nedi, Netdata's AI assistant, questions about Netdata documentation, configuration, monitoring, and troubleshooting.";
 
 function renderedMetadata(html) {
   const values = new Map();
@@ -32,7 +31,7 @@ describe('ask Nedi metadata', () => {
         description: 'Generated loading fallback',
         permalink: '/docs/ask-nedi',
       }),
-    ).toBe(ASK_NEDI_DESCRIPTION);
+    ).toBe(expectedAskNediDescription);
     expect(
       resolveDocDescription({
         description: 'Another page description',
@@ -53,8 +52,8 @@ describe('ask Nedi metadata', () => {
       'utf8',
     );
     const metadata = renderedMetadata(html);
-    expect(metadata.get('description')).toBe(ASK_NEDI_DESCRIPTION);
-    expect(metadata.get('og:description')).toBe(ASK_NEDI_DESCRIPTION);
+    expect(metadata.get('description')).toBe(expectedAskNediDescription);
+    expect(metadata.get('og:description')).toBe(expectedAskNediDescription);
     expect(metadata.get('description')).not.toContain('Loading Ask Nedi');
     expect(metadata.get('og:description')).not.toContain('Loading Ask Nedi');
   });

--- a/src/seo/askNediMetadata.test.js
+++ b/src/seo/askNediMetadata.test.js
@@ -1,0 +1,47 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import {parse} from 'parse5';
+import {describe, expect, it} from 'vitest';
+
+
+const root = path.resolve(import.meta.dirname, '../..');
+const expectedDescription =
+  "Ask Nedi, Netdata's AI assistant, questions about Netdata documentation, configuration, monitoring, and troubleshooting.";
+
+function frontMatterDescription(source) {
+  const match = source.match(/^description:\s*["'](.*)["']\s*$/m);
+  return match?.[1] ?? null;
+}
+
+function renderedMetadata(html) {
+  const values = new Map();
+  const visit = (node) => {
+    if (node.nodeName === 'meta') {
+      const attrs = Object.fromEntries((node.attrs ?? []).map(({name, value}) => [name, value]));
+      const key = attrs.name || attrs.property;
+      if (key) values.set(key.toLowerCase(), attrs.content ?? '');
+    }
+    for (const child of node.childNodes ?? []) visit(child);
+  };
+  visit(parse(html));
+  return values;
+}
+
+describe('Ask Nedi metadata', () => {
+  it('pins the exact authored description in document front matter', () => {
+    const source = fs.readFileSync(path.join(root, 'docs/ask-nedi.mdx'), 'utf8');
+    expect(frontMatterDescription(source)).toBe(expectedDescription);
+  });
+
+  it.skipIf(!process.env.BUILT_SITE_DIR)('renders the exact description and Open Graph description', () => {
+    const html = fs.readFileSync(
+      path.join(process.env.BUILT_SITE_DIR, 'docs/ask-nedi/index.html'),
+      'utf8',
+    );
+    const metadata = renderedMetadata(html);
+    expect(metadata.get('description')).toBe(expectedDescription);
+    expect(metadata.get('og:description')).toBe(expectedDescription);
+    expect(metadata.get('description')).not.toContain('Loading Ask Nedi');
+    expect(metadata.get('og:description')).not.toContain('Loading Ask Nedi');
+  });
+});

--- a/src/seo/askNediMetadata.test.js
+++ b/src/seo/askNediMetadata.test.js
@@ -1,17 +1,15 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import process from 'node:process';
 import {parse} from 'parse5';
 import {describe, expect, it} from 'vitest';
 
+import {
+  ASK_NEDI_DESCRIPTION,
+  resolveDocDescription,
+} from './description';
 
-const root = path.resolve(import.meta.dirname, '../..');
-const expectedDescription =
-  "Ask Nedi, Netdata's AI assistant, questions about Netdata documentation, configuration, monitoring, and troubleshooting.";
-
-function frontMatterDescription(source) {
-  const match = source.match(/^description:\s*["'](.*)["']\s*$/m);
-  return match?.[1] ?? null;
-}
+const buildRoot = process.env.BUILT_SITE_DIR;
 
 function renderedMetadata(html) {
   const values = new Map();
@@ -27,20 +25,36 @@ function renderedMetadata(html) {
   return values;
 }
 
-describe('Ask Nedi metadata', () => {
-  it('pins the exact authored description in document front matter', () => {
-    const source = fs.readFileSync(path.join(root, 'docs/ask-nedi.mdx'), 'utf8');
-    expect(frontMatterDescription(source)).toBe(expectedDescription);
+describe('ask Nedi metadata', () => {
+  it('uses the approved description only for the exact Ask Nedi permalink', () => {
+    expect(
+      resolveDocDescription({
+        description: 'Generated loading fallback',
+        permalink: '/docs/ask-nedi',
+      }),
+    ).toBe(ASK_NEDI_DESCRIPTION);
+    expect(
+      resolveDocDescription({
+        description: 'Another page description',
+        permalink: '/docs/ask-nedi/extra',
+      }),
+    ).toBe('Another page description');
+    expect(
+      resolveDocDescription({
+        description: 'Another page description',
+        permalink: '/docs/netdata-agent',
+      }),
+    ).toBe('Another page description');
   });
 
-  it.skipIf(!process.env.BUILT_SITE_DIR)('renders the exact description and Open Graph description', () => {
+  it.skipIf(!buildRoot)('renders the exact description and Open Graph description', () => {
     const html = fs.readFileSync(
-      path.join(process.env.BUILT_SITE_DIR, 'docs/ask-nedi/index.html'),
+      path.join(buildRoot, 'docs/ask-nedi/index.html'),
       'utf8',
     );
     const metadata = renderedMetadata(html);
-    expect(metadata.get('description')).toBe(expectedDescription);
-    expect(metadata.get('og:description')).toBe(expectedDescription);
+    expect(metadata.get('description')).toBe(ASK_NEDI_DESCRIPTION);
+    expect(metadata.get('og:description')).toBe(ASK_NEDI_DESCRIPTION);
     expect(metadata.get('description')).not.toContain('Loading Ask Nedi');
     expect(metadata.get('og:description')).not.toContain('Loading Ask Nedi');
   });

--- a/src/seo/description.js
+++ b/src/seo/description.js
@@ -1,0 +1,8 @@
+export const ASK_NEDI_DESCRIPTION =
+  "Ask Nedi, Netdata's AI assistant, questions about Netdata documentation, configuration, monitoring, and troubleshooting.";
+
+const ASK_NEDI_PERMALINK = '/docs/ask-nedi';
+
+export function resolveDocDescription({description, permalink}) {
+  return permalink === ASK_NEDI_PERMALINK ? ASK_NEDI_DESCRIPTION : description;
+}

--- a/src/theme/DocItem/Metadata/index.js
+++ b/src/theme/DocItem/Metadata/index.js
@@ -4,6 +4,7 @@ import {
   useDoc,
   useSidebarBreadcrumbs,
 } from '@docusaurus/plugin-content-docs/client';
+import {resolveDocDescription} from '@site/src/seo/description';
 import {composeDocTitle} from '@site/src/seo/title';
 
 export default function DocItemMetadata() {
@@ -16,10 +17,14 @@ export default function DocItemMetadata() {
     permalink: metadata.permalink,
     breadcrumbs,
   });
+  const description = resolveDocDescription({
+    description: metadata.description,
+    permalink: metadata.permalink,
+  });
   return (
     <PageMetadata
       title={title}
-      description={metadata.description}
+      description={description}
       keywords={frontMatter.keywords}
       image={assets.image ?? frontMatter.image}
     />


### PR DESCRIPTION
## Summary

- Resolve the approved Ask Nedi description in the source-owned document metadata layer.
- Apply it only to the exact `/docs/ask-nedi` permalink; every other document keeps its existing description.
- Test exact-route selection and the rendered `description` and `og:description` tags.

## Scope and compatibility

- No generated file under `docs/` is changed by the final PR diff.
- Only Ask Nedi metadata changes.
- The Learn home redirect, page application behavior, content, and indexing policy are unchanged.

## Validation

- Required Node.js 22 production build: successful.
- Focused source tests: 9 passed, 1 expected rendered-output skip before build.
- Focused rendered metadata tests: 2 passed.
- Vitest suite with rendered output: 453 passed.
- IndexNow tests: 64 passed.
- Swagger vendor tests: 2 passed.
- Dependency-authority tests: 3 passed.
- Site-build-gate tests: 4 passed.
- Rendered site gate: 1,987 pages, zero findings or regressions.

The production build continues to report existing broken-anchor and HTML-minifier warnings on unrelated documentation routes; all required gates pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Ask Nedi documentation page metadata with a consistent, approved description.
  * Search results and social media previews now display the correct Ask Nedi description.
  * Removed the temporary “Loading Ask Nedi” text from the page’s metadata, improving how the page appears when shared or indexed.
* **Tests**
  * Added coverage to verify the Ask Nedi description is applied only to the intended page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->