### PR TITLE
Update Nedi Viz.js CDN asset to 3.30.0

### DIFF
--- a/src/components/Nedi/assets.js
+++ b/src/components/Nedi/assets.js
@@ -22,8 +22,8 @@ export const NEDI_ASSETS = [
   },
   {
     type: 'js',
-    src: 'https://cdn.jsdelivr.net/npm/@viz-js/viz@3.29.0/dist/viz-global.js',
-    integrity: 'sha384-39ZxW8vr+xPchaaptsOWpdQjpckcdy40zkLeHLA4Yv3x0el06s2iBnWQ/s/ppFXQ',
+    src: 'https://cdn.jsdelivr.net/npm/@viz-js/viz@3.30.0/dist/viz-global.js',
+    integrity: 'sha384-KtL79YzRfvZ8ULC1SlgbwCIy18KoEk5fAudzHYqetJVonV6ubRN1KD2sDvNT9uuX',
   },
   {
     type: 'js',


### PR DESCRIPTION
## Summary

- Update the Nedi Graphviz browser dependency from Viz.js 3.29.0 to 3.30.0.
- Replace the Subresource Integrity hash with the independently verified SHA-384 digest for the immutable 3.30.0 jsDelivr asset.
- Preserve the existing Nedi asset API, ordering, and cache-buster behavior.

## Compatibility

- Viz.js 3.30.0 updates its bundled Graphviz, Expat, and Emscripten toolchain without a JavaScript API change.
- Browser validation passed with both baseline and candidate Nedi producers.

## Validation

- Frozen Yarn install
- Focused Nedi tests: 44 passed
- Complete test command: Vitest 452 passed / 1 skipped; IndexNow 64 passed; Swagger vendor 2 passed; dependency authority 3 passed; site-build gate 4 passed under the repository-declared Node 22.23.2 runtime
- Production build
- Real Chromium DOT-to-SVG rendering with SRI enforcement against baseline and candidate Nedi producers
- CDN SHA-384 digest independently reproduced


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Nedi Graphviz browser dependency `@viz-js/viz` from 3.29.0 to 3.30.0.

- Replaces the Subresource Integrity hash with the independently verified SHA-384 digest for the 3.30.0 CDN asset.
- Viz.js 3.30.0 has no JavaScript API change, so the Nedi asset API, ordering, and cache-buster behavior stay the same.

<sup>Written for commit 21a98e5f637c037582dbc138018e51a75a210447. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/netdata/learn/pull/3073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled visualization asset to version 3.30.0.
  * Updated its integrity verification data to match the new asset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->